### PR TITLE
Makefile rework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,95 +1,132 @@
 # Makefile :)
-OS_UNAME =  $(shell uname -s)
+NAME     := rvvm
+SRCDIR   := src
+
+# OS-specific configuration
+OS_UNAME := $(shell uname -s)
+ARCH     := $(shell uname -m)
 
 ifeq ($(OS_UNAME),Linux)
-OS = linux
-PROGRAMEXT =
+OS         := linux
+PROGRAMEXT :=
+OS_CFLAGS  := -pthread -lX11 -DUSE_X11
+else ifeq ($(OS_UNAME),FreeBSD)
+OS         := freebsd
+PROGRAMEXT :=
+OS_CFLAGS  := -pthread -lX11 -DUSE_X11
 else
-OS = windows
-PROGRAMEXT = .exe
+OS         := windows
+PROGRAMEXT := .exe
+OS_CFLAGS  := -pthread
 endif
 
-ifeq ($(OS_UNAME),FreeBSD)
-OS = freebsd
-PROGRAMEXT =
-endif
-
-SRCDIR = src
-
-NAME = rvvm
-
-ifeq ($(CLANG),1)
-CC = clang
-CXX = clang++
-else ifeq ($(TCC),1)
-CC= tcc
-else
-CC = cc
-CXX = c++
-endif
-
-OPT_CFLAGS = -O2 -flto -pthread
-
-BASE_CFLAGS = -std=gnu11 -DVERSION=\"$(VERSION)\" -DARCH=\"$(ARCH)\" -Wall -Wextra
-
-ARCH=$(shell uname -m)
-
-COMMIT := $(firstword $(shell git rev-parse --short=6 HEAD) unknown)
-
+# Optimization/debug flags
 ifeq ($(DEBUG),1)
-BUILD_TYPE = debug
-BUILD_TYPE_CFLAGS = -Og -ggdb -DDEBUG
+BUILD_TYPE        := debug
+BUILD_TYPE_CFLAGS := -Og -ggdb -DDEBUG
 #-fsanitize=undefined -fsanitize=address -fsanitize=thread
 else
-BUILD_TYPE = release
-BUILD_TYPE_CFLAGS = $(OPT_CFLAGS) -DNDEBUG
-DEBUG = 0
+BUILD_TYPE        := release
+BUILD_TYPE_CFLAGS := -O2 -flto -fwhole-program -DNDEBUG
 endif
 
+# Version string
+COMMIT  := $(firstword $(shell git rev-parse --short=6 HEAD) unknown)
 VERSION := $(COMMIT)-$(BUILD_TYPE)
 
-OBJDIR = $(BUILD_TYPE).$(OS).$(ARCH)
+# Generic compiler flags
+BASE_CFLAGS := -std=gnu11 -DVERSION=\"$(VERSION)\" -DARCH=\"$(ARCH)\" -Wall -Wextra -I. -I$(SRCDIR) $(OS_CFLAGS)
+CFLAGS += $(BASE_CFLAGS) $(BUILD_TYPE_CFLAGS)
 
-CFLAGS = $(BUILD_TYPE_CFLAGS) $(BASE_CFLAGS) $(ARCH_CFLAGS)
+# Choose compiler
+# (but actually you just need to pass CC/CXX variable to make for this)
+ifeq ($(CLANG),1)
+CC  := clang
+CXX := clang++
+else ifeq ($(TCC),1)
+CC  := tcc
+else
+CC  := cc
+CXX := c++
+endif
 
-INCLUDE = -I. -I$(SRCDIR)
+DO_CC  = $(CC) $(CFLAGS) $(TARGET_ARCH) -o $@ -c $<
+DO_CXX = $(CXX) $(CFLAGS) $(TARGET_ARCH) -o $@ -c $<
 
-LDFLAGS += $(OPT_CFLAGS)
+OBJDIR := $(BUILD_TYPE).$(OS).$(ARCH)
 
-DO_CC = $(CC) $(CFLAGS) $(INCLUDE) -o $@ -c $<
-DO_CXX = $(CXX) $(CFLAGS) $(INCLUDE) -o $@ -c $<
+# Generic sources
+SRC           := $(wildcard $(SRCDIR)/*.c $(SRCDIR)/*.cpp)
+OBJ_GENERIC32 := $(SRC:$(SRCDIR)/%.c=$(OBJDIR)/%.32.o)
+OBJ_GENERIC64 := $(SRC:$(SRCDIR)/%.c=$(OBJDIR)/%.64.o)
 
+# Rules to build CPU object files for different architectures
+SRC_CPU   := $(wildcard $(SRCDIR)/cpu/*.c $(SRCDIR)/cpu/*.cpp)
+OBJ_CPU32 := $(SRC_CPU:$(SRCDIR)/%.c=$(OBJDIR)/%.32.o)
+OBJ_CPU64 := $(SRC_CPU:$(SRCDIR)/%.c=$(OBJDIR)/%.64.o)
+SRC += $(SRC_CPU)
+
+# Make directory if we need to.
+# This is really ugly, the proper solution would be a dependency on
+# an object file directory, but unfortunately we can't do that :(
+MKDIR_FOR_TARGET = @mkdir -p $(@D)
+
+# RV64
+$(OBJDIR)/%.64.o: $(SRCDIR)/%.c Makefile
+	$(MKDIR_FOR_TARGET)
+	$(DO_CC) -DRV64
+
+$(OBJDIR)/%.64.o: $(SRCDIR)/%.cpp Makefile
+	$(MKDIR_FOR_TARGET)
+	$(DO_CXX) -DRV64
+
+# RV32 (no defines)
+$(OBJDIR)/%.32.o: $(SRCDIR)/%.c Makefile
+	$(MKDIR_FOR_TARGET)
+	$(DO_CC)
+
+$(OBJDIR)/%.32.o: $(SRCDIR)/%.cpp Makefile
+	$(MKDIR_FOR_TARGET)
+	$(DO_CXX)
+
+# Default rules for generic code (should not be used, left just in case)
 $(OBJDIR)/%.o: $(SRCDIR)/%.c Makefile
+	$(MKDIR_FOR_TARGET)
 	$(DO_CC)
 
 $(OBJDIR)/%.o: $(SRCDIR)/%.cpp Makefile
+	$(MKDIR_FOR_TARGET)
 	$(DO_CXX)
 
-SRC := $(wildcard $(SRCDIR)/*.c $(SRCDIR)/*.cpp)
-OBJ := $(SRC:$(SRCDIR)/%.c=$(OBJDIR)/%.o)
-DEPEND := $(OBJDIR)/Rules.depend
-
-TARGET := $(OBJDIR)/$(NAME)_$(ARCH)$(PROGRAMEXT)
+DEPEND   := $(OBJDIR)/Rules.depend
+TARGET   := $(OBJDIR)/$(NAME)_$(ARCH)$(PROGRAMEXT)
+TARGET64 := $(OBJDIR)/$(NAME)64_$(ARCH)$(PROGRAMEXT)
 
 .PHONY: all
-all: $(TARGET)
+all: $(TARGET) $(TARGET64)
 
-$(TARGET): $(OBJDIR) $(DEPEND) $(OBJ)
-	$(CC) $(CFLAGS) $(OBJ) $(LDFLAGS) -o $@
+$(TARGET): $(DEPEND) $(OBJ_GENERIC32) $(OBJ_CPU32)
+	$(CC) $(CFLAGS) $(OBJ_GENERIC32) $(OBJ_CPU32) $(LDFLAGS) -o $@
+
+$(TARGET64): $(DEPEND) $(OBJ_GENERIC64) $(OBJ_CPU32) $(OBJ_CPU64)
+	$(CC) $(CFLAGS) $(OBJ_GENERIC64) $(OBJ_CPU32) $(OBJ_CPU64) $(LDFLAGS) -o $@
 
 .PHONY: neat
 neat: $(OBJDIR)
 
 $(OBJDIR):
-	@mkdir -p $(OBJDIR)
+	mkdir -p $(OBJDIR)
 
 .PHONY: clean
 clean: depend
 	-rm -f $(OBJDIR)/*.so
-	-rm -f $(OBJ)
-	-rm -f $(TARGET)
+	-rm -f $(OBJ_GENERIC32)
+	-rm -f $(OBJ_GENERIC64)
+	-rm -f $(OBJ_CPU32)
+	-rm -f $(OBJ_CPU64)
+	-rm -f $(TARGET) $(TARGET64)
 	-rm -f $(OBJDIR)/Rules.depend
-	-rmdir $(OBJDIR)
+	-find $(OBJDIR)/ -depth -type d -exec rmdir {} +
 
 .PHONY: depend
 depend: $(DEPEND)

--- a/src/riscv32.c
+++ b/src/riscv32.c
@@ -76,7 +76,9 @@ static void* global_irq_handler(void* arg)
             vm->wait_event = 0;
         }
         spin_unlock(&global_lock);
+#ifdef USE_X11
         update_fb();
+#endif
     }
     return arg;
 }
@@ -114,6 +116,7 @@ static void deregister_vm(riscv32_vm_state_t *vm)
     spin_unlock(&global_lock);
 }
 
+#ifdef USE_X11
 static bool fb_mmio_handler(riscv32_vm_state_t* vm, riscv32_mmio_device_t* device, uint32_t offset, void* data, uint32_t size, uint8_t op)
 {
     uint8_t* devptr = ((uint8_t*)device->data) + offset;
@@ -133,6 +136,7 @@ static void init_fb(riscv32_vm_state_t* vm, uint32_t addr)
     riscv32_mmio_add_device(vm, addr, addr + (640*480*4), fb_mmio_handler, tmp);
     create_window(tmp, 640, 480, "RVVM");
 }
+#endif
 
 riscv32_vm_state_t *riscv32_create_vm()
 {
@@ -161,7 +165,9 @@ riscv32_vm_state_t *riscv32_create_vm()
     riscv32_tlb_flush(vm);
     ns16550a_init(vm, 0x10000000);
     riscv32_mmio_add_device(vm, 0x2000000, 0x2010000, clint_mmio_handler, NULL);
+#ifdef USE_X11
     init_fb(vm, 0x30000000);
+#endif
     rvtimer_init(&vm->timer, 0x989680); // 10 MHz timer
     vm->mmu_virtual = false;
     vm->priv_mode = PRIVILEGE_MACHINE;


### PR DESCRIPTION
Set up build system to build RV64 CPU configuration.
It now builds 2 different binaries - one is 32-bit,
and the other is 64 (actually it's 32 for now because no
64-bit support is implemented yet).

Other minor fixes were made, such as removing OPT_CFLAGS from
LDFLAGS and passing OS-specific options - X11 build flag
now uses this.

Makefile was reorganized to have more logical structure.