### PR TITLE
Fixes for Nokia N900

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,10 @@ $(info Detected OS: Windows)
 ifndef ARCH
 ifeq ($(PROCESSOR_ARCHITEW6432),AMD64)
 ARCH := x86_64
-else ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
+else
+ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
 ARCH := x86_64
+endif
 endif
 
 ifeq ($(PROCESSOR_ARCHITECTURE),x86)
@@ -35,21 +37,27 @@ OS_UNAME := $(shell uname -s)
 ifeq ($(OS_UNAME),Linux)
 OS := linux
 $(info Detected OS: Linux)
-else ifneq (,$(findstring BSD,$(OS_UNAME)))
+else
+ifneq (,$(findstring BSD,$(OS_UNAME)))
 OS := bsd
 $(info Detected OS: BSD)
-else ifeq ($(OS_UNAME),Darwin)
+else
+ifeq ($(OS_UNAME),Darwin)
 OS := darwin
 $(info Detected OS: Darwin/MacOS)
 else
 OS := unknown
 $(warning [WARN] Unknown OS)
 endif
+endif
+endif
 
-else ifneq ($(WIN_SET),1)
+else
+ifneq ($(WIN_SET),1)
 $(info Chosen OS: $(OS))
 endif
 
+endif
 
 # Set up OS options
 ifeq ($(OS),windows)
@@ -65,12 +73,14 @@ CC_HELP := $(shell $(CC) --help $(NULL_STDERR))
 ifneq (,$(findstring clang,$(CC_HELP)))
 CC_TYPE := clang
 $(info Detected compiler: LLVM Clang)
-else ifneq (,$(findstring gcc,$(CC_HELP)))
+else
+ifneq (,$(findstring gcc,$(CC_HELP)))
 CC_TYPE := gcc
 $(info Detected compiler: GCC)
 else
 CC_TYPE := unknown
 $(warning [WARN] Unknown compiler)
+endif
 endif
 
 
@@ -78,8 +88,10 @@ endif
 ifndef ARCH
 ifeq ($(CC_TYPE),gcc)
 ARCH := $(firstword $(subst -, ,$(shell $(CC) $(CFLAGS) -print-multiarch $(NULL_STDERR))))
-else ifeq ($(CC_TYPE),clang)
+else
+ifeq ($(CC_TYPE),clang)
 ARCH := $(firstword $(subst -, ,$(shell $(CC) $(CFLAGS) -dumpmachine $(NULL_STDERR))))
+endif
 endif
 
 
@@ -104,11 +116,13 @@ BUILD_TYPE := release
 override CFLAGS += -DNDEBUG
 ifeq ($(CC_TYPE),gcc)
 override CFLAGS += -O3 -flto
-else ifeq ($(CC_TYPE),clang)
+else
+ifeq ($(CC_TYPE),clang)
 override CFLAGS += -Ofast -flto
 else
 # Whatever compiler that might be, lets not enable aggressive optimizations
 override CFLAGS += -O2
+endif
 endif
 
 endif
@@ -130,6 +144,10 @@ USE_XSHM ?= 1
 USE_RV64 ?= 0
 USE_JIT ?= 0
 USE_NET ?= 0
+
+ifeq ($(OS),linux)
+override LDFLAGS += -lrt
+endif
 
 ifeq ($(USE_FB),1)
 override CFLAGS += -DUSE_FB

--- a/src/elf_load.c
+++ b/src/elf_load.c
@@ -30,6 +30,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <elf.h>
 
+#ifndef PN_XNUM
+#define PN_XNUM 0xffff
+#endif
 
 bool riscv32_elf_load_by_path(riscv32_vm_state_t *vm, const char *path, bool use_mmu, ssize_t offset)
 {

--- a/src/rvtimer.c
+++ b/src/rvtimer.c
@@ -22,6 +22,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <unistd.h>
 #include <time.h>
 #define HAS_CLOCK_GETTIME
+
+#ifndef CLOCK_MONOTONIC_RAW
+#define CLOCK_MONOTONIC_RAW CLOCK_MONOTONIC
+#endif
+
 #elif defined(BSD)
 #include <unistd.h>
 #include <time.h>


### PR DESCRIPTION
Now successfully builds & runs on this old device, yay!

Ancient GNU Make doesn't support 'if' directives like:

	ifeq ($(STUFF),foo)
	else ifeq ($(STUFF),bar)
	endif

So this is changed to:

	ifeq ($(STUFF),foo)
	else
	ifeq ($(STUFF),bar)
	endif
	endif

A bit painful to read, but works.

Some headers are also old, so we try to workaround it:
 - CLOCK_MONOTONIC_RAW is not present in Nokia's kernel headers,
   possibly no kernel support too, so we fallback to CLOCK_MONOTONIC.
 - PN_XNUM is also nonexistent, so we use it's hardcoded value.
 - Older GCC requires linking with librt for clock_gettime to work.
   Don't know about other platforms, so enable it for Linux only.