### PR TITLE
Make networking work on SerenityOS

### DIFF
--- a/src/devices/rtl8169.c
+++ b/src/devices/rtl8169.c
@@ -702,7 +702,7 @@ PUBLIC pci_dev_t* rtl8169_init(pci_bus_t* pci_bus, tap_dev_t* tap)
 
     pci_func_desc_t rtl8169_desc = {
         .vendor_id = 0x10EC,  // Realtek
-        .device_id = 0x8169,  // RTL8169 Gigabit NIC
+        .device_id = 0x8168,  // RTL8168 Gigabit NIC
         .class_code = 0x0200, // Ethernet
         .irq_pin = PCI_IRQ_PIN_INTA,
         .bar[1] = {

--- a/src/devices/tap_user.c
+++ b/src/devices/tap_user.c
@@ -288,7 +288,7 @@ static void handle_icmp(tap_dev_t* tap, const uint8_t* buffer, size_t size, net_
     }
 }
 
-static void handle_dhcp(tap_dev_t* tap, const uint8_t* buffer, size_t size, net_addr_t* dst, net_addr_t* src)
+static void handle_dhcp(tap_dev_t* tap, const uint8_t* buffer, size_t size, net_addr_t* src)
 {
     if (unlikely(size < 240)) {
         // Packet too small
@@ -311,7 +311,7 @@ static void handle_dhcp(tap_dev_t* tap, const uint8_t* buffer, size_t size, net_
     uint8_t frame[TAP_FRAME_SIZE];
     uint8_t* ipv4 = create_eth_frame(tap, frame, ETH2_IPv4);
     uint8_t* udp = create_ipv4_frame(ipv4, 277 + UDP_HDR_SIZE, IP_PROTO_UDP, (const uint8_t*)"\xFF\xFF\xFF\xFF", GATEWAY_IP);
-    uint8_t* dhcp = create_udp_datagram(udp, 277, src->port, dst->port);
+    uint8_t* dhcp = create_udp_datagram(udp, 277, 68, 67);
 
     dhcp[0] = OP_RESPONSE;
     dhcp[1] = HTYPE_ETHER;
@@ -412,7 +412,7 @@ static void handle_udp(tap_dev_t* tap, const uint8_t* buffer, size_t size, net_a
     if (ts == NULL) {
         if (dst->port == 67 && (read_uint32_be_m(src->ip) == 0)) {
             spin_unlock(&tap->lock);
-            handle_dhcp(tap, udb_buff, udp_size, dst, src);
+            handle_dhcp(tap, udb_buff, udp_size, src);
             return;
         }
 

--- a/src/devices/tap_user.c
+++ b/src/devices/tap_user.c
@@ -310,8 +310,8 @@ static void handle_dhcp(tap_dev_t* tap, const uint8_t* buffer, size_t size, net_
 
     uint8_t frame[TAP_FRAME_SIZE];
     uint8_t* ipv4 = create_eth_frame(tap, frame, ETH2_IPv4);
-    uint8_t* udp = create_ipv4_frame(ipv4, 277 + UDP_HDR_SIZE, IP_PROTO_UDP, (const uint8_t*)"\xFF\xFF\xFF\xFF", GATEWAY_IP);
-    uint8_t* dhcp = create_udp_datagram(udp, 277, 68, 67);
+    uint8_t* udp = create_ipv4_frame(ipv4, 278 + UDP_HDR_SIZE, IP_PROTO_UDP, (const uint8_t*)"\xFF\xFF\xFF\xFF", GATEWAY_IP);
+    uint8_t* dhcp = create_udp_datagram(udp, 278, 68, 67);
 
     dhcp[0] = OP_RESPONSE;
     dhcp[1] = HTYPE_ETHER;
@@ -360,8 +360,9 @@ static void handle_dhcp(tap_dev_t* tap, const uint8_t* buffer, size_t size, net_
     dhcp[268] = 8;
     write_uint32_be_m(dhcp + 269, 0x01010101);
     write_uint32_be_m(dhcp + 273, 0x08080808);
+    dhcp[277] = DHCP_ENDMARK;
 
-    eth_send(tap, frame, 277 + UDP_HDR_SIZE + IPv4_HDR_SIZE + ETH2_HDR_SIZE);
+    eth_send(tap, frame, 278 + UDP_HDR_SIZE + IPv4_HDR_SIZE + ETH2_HDR_SIZE);
 }
 
 // Filter unwanted outbound traffic to special IPs


### PR DESCRIPTION
These changes are necessary for making networking work on SerenityOS with its RTL8168 driver.

SerenityOS currently tries to use BAR0, while RVVM only sets BAR1. The RTL8168B datasheet says that BAR0 should be the IO BAR and BAR2 should be a memory space BAR (don't know about the RTL8169).
Patching SerenityOS to use BAR1 and applying this PR makes `Browser` successfully load the serenityos.org website!

Since RVVM doesn't have any input devices that SerenityOS supports, you need to manually add the following lines to `Base/etc/shellrc` to test this:
```sh
if [ "$(id -u)" != "0" ] {
    echo 'ntqpuery -s'
    su -c 'ntpquery -s'
    echo 'Browser serenityos.org'
    Browser serenityos.org
}
```
(the `ntpquery -s` is necessary because we only have an x86 RTC driver currently)

You can boot SerenityOS by running U-Boot `bootefi` on the Kernel.efi file:
`env set bootargs 'serial_debug root=nvme0:1:0'; nvme scan; load nvme 0 $kernel_addr_r /boot/Kernel.efi; bootefi $kernel_addr_r`