### PR TITLE
allow wasm terminal input

### DIFF
--- a/src/devices/chardev_term.c
+++ b/src/devices/chardev_term.c
@@ -11,7 +11,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #include "chardev.h"
 #include <stdio.h> // For fputs(), setvbuf()
 
-#if (defined(__unix__) || defined(__APPLE__) || defined(__HAIKU__)) && !defined(__EMSCRIPTEN__)
+#if (defined(__unix__) || defined(__APPLE__) || defined(__HAIKU__)) || defined(__EMSCRIPTEN__)
 #include <fcntl.h>    // For open()
 #include <sys/time.h> // For select()
 #include <termios.h>  // For tcgetattr(), tcsetattr(), etc

--- a/src/devices/chardev_term.c
+++ b/src/devices/chardev_term.c
@@ -11,7 +11,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #include "chardev.h"
 #include <stdio.h> // For fputs(), setvbuf()
 
-#if (defined(__unix__) || defined(__APPLE__) || defined(__HAIKU__)) || defined(__EMSCRIPTEN__)
+#if defined(__unix__) || defined(__APPLE__) || defined(__HAIKU__)
 #include <fcntl.h>    // For open()
 #include <sys/time.h> // For select()
 #include <termios.h>  // For tcgetattr(), tcsetattr(), etc


### PR DESCRIPTION
allow terminal input when used with xterm.js

yes it just works.

![imatge](https://github.com/user-attachments/assets/0d46ae66-7192-4fb8-88b9-a3f96ff9e281)
