### PR TITLE
sound-hda: Correct stream management, working ALSA backend

### DIFF
--- a/src/devices/alsa.c
+++ b/src/devices/alsa.c
@@ -1,0 +1,142 @@
+/*
+alsa.c - ALSA sound backend
+Copyright (C) 2025  David Korenchuk <github.com/epoll-reactor-2>
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+
+#ifdef USE_ALSA
+
+#include "compiler.h"
+#include "dlib.h"
+#include "sound-hda.h"
+#include "utils.h"
+
+
+#if CHECK_INCLUDE(alsa/asoundlib.h, 1)
+#include <alsa/asoundlib.h>
+#endif
+
+#define ASOUND_DLIB_SYM(sym) static __typeof__(sym) *MACRO_CONCAT(sym, _dlib) = NULL;
+
+ASOUND_DLIB_SYM(snd_pcm_open)
+ASOUND_DLIB_SYM(snd_pcm_hw_params_malloc)
+ASOUND_DLIB_SYM(snd_pcm_hw_params_any)
+ASOUND_DLIB_SYM(snd_pcm_hw_params_set_access)
+ASOUND_DLIB_SYM(snd_pcm_hw_params_set_format)
+ASOUND_DLIB_SYM(snd_pcm_hw_params_set_channels)
+ASOUND_DLIB_SYM(snd_pcm_hw_params_set_rate_near)
+ASOUND_DLIB_SYM(snd_pcm_hw_params_set_period_size_near)
+ASOUND_DLIB_SYM(snd_pcm_hw_params)
+ASOUND_DLIB_SYM(snd_pcm_writei)
+ASOUND_DLIB_SYM(snd_pcm_prepare)
+ASOUND_DLIB_SYM(snd_pcm_drain)
+ASOUND_DLIB_SYM(snd_pcm_close)
+ASOUND_DLIB_SYM(snd_pcm_hw_params_free)
+
+#define snd_pcm_open snd_pcm_open_dlib
+#define snd_pcm_hw_params_malloc snd_pcm_hw_params_malloc_dlib
+#define snd_pcm_hw_params_any snd_pcm_hw_params_any_dlib
+#define snd_pcm_hw_params_set_access snd_pcm_hw_params_set_access_dlib
+#define snd_pcm_hw_params_set_format snd_pcm_hw_params_set_format_dlib
+#define snd_pcm_hw_params_set_channels snd_pcm_hw_params_set_channels_dlib
+#define snd_pcm_hw_params_set_rate_near snd_pcm_hw_params_set_rate_near_dlib
+#define snd_pcm_hw_params_set_period_size_near snd_pcm_hw_params_set_period_size_near_dlib
+#define snd_pcm_hw_params snd_pcm_hw_params_dlib
+#define snd_pcm_writei snd_pcm_writei_dlib
+#define snd_pcm_prepare snd_pcm_prepare_dlib
+#define snd_pcm_drain snd_pcm_drain_dlib
+#define snd_pcm_close snd_pcm_close_dlib
+#define snd_pcm_hw_params_free snd_pcm_hw_params_free_dlib
+
+typedef struct {
+    snd_pcm_t *pcm_handle;
+} alsa_subsystem_t;
+
+static void alsa_sound_write(sound_subsystem_t *subsystem, void *data, size_t size)
+{
+    alsa_subsystem_t *alsa = subsystem->sound_data;
+
+    if (snd_pcm_writei(alsa->pcm_handle, data, size / 2) == -EPIPE)
+        snd_pcm_prepare(alsa->pcm_handle);
+}
+
+static bool alsa_load_symbols(void)
+{
+    dlib_ctx_t *libasound = dlib_open("asound", DLIB_NAME_PROBE);
+    if (libasound == NULL) {
+        rvvm_warn("Cannot load libasound.so");
+        return 0;
+    }
+
+    bool avail = 1;
+
+#define ASOUND_DLIB_RESOLVE(lib, sym) \
+do { \
+    sym = dlib_resolve(lib, #sym); \
+    avail = avail && !!sym; \
+} while (0)
+
+    ASOUND_DLIB_RESOLVE(libasound, snd_pcm_open);
+    ASOUND_DLIB_RESOLVE(libasound, snd_pcm_hw_params_malloc);
+    ASOUND_DLIB_RESOLVE(libasound, snd_pcm_hw_params_any);
+    ASOUND_DLIB_RESOLVE(libasound, snd_pcm_hw_params_set_access);
+    ASOUND_DLIB_RESOLVE(libasound, snd_pcm_hw_params_set_format);
+    ASOUND_DLIB_RESOLVE(libasound, snd_pcm_hw_params_set_channels);
+    ASOUND_DLIB_RESOLVE(libasound, snd_pcm_hw_params_set_rate_near);
+    ASOUND_DLIB_RESOLVE(libasound, snd_pcm_hw_params_set_period_size_near);
+    ASOUND_DLIB_RESOLVE(libasound, snd_pcm_hw_params);
+    ASOUND_DLIB_RESOLVE(libasound, snd_pcm_writei);
+    ASOUND_DLIB_RESOLVE(libasound, snd_pcm_prepare);
+    ASOUND_DLIB_RESOLVE(libasound, snd_pcm_drain);
+    ASOUND_DLIB_RESOLVE(libasound, snd_pcm_close);
+    ASOUND_DLIB_RESOLVE(libasound, snd_pcm_hw_params_free);
+
+    dlib_close(libasound);
+
+    return avail;
+}
+
+bool alsa_sound_init(sound_subsystem_t *sound)
+{
+    bool libasound_avail = true;
+    DO_ONCE(libasound_avail = alsa_load_symbols());
+    if (!libasound_avail) {
+        rvvm_error("Could not load libasound.so");
+        return false;
+    }
+
+    alsa_subsystem_t *subsystem = safe_new_obj(alsa_subsystem_t);
+    if (snd_pcm_open(&subsystem->pcm_handle, "default", SND_PCM_STREAM_PLAYBACK, 0) < 0) {
+        rvvm_warn("Failed to open ALSA device");
+        return false;
+    }
+
+    snd_pcm_t *pcm_device = subsystem->pcm_handle;
+    snd_pcm_hw_params_t *params = NULL;
+    unsigned int sample_rate = 192000;
+    int channels = 1;
+    snd_pcm_uframes_t frames = 128;
+    int dir = 0;
+
+    snd_pcm_hw_params_malloc(&params);
+    snd_pcm_hw_params_any(pcm_device, params);
+
+    snd_pcm_hw_params_set_access(pcm_device, params, SND_PCM_ACCESS_RW_INTERLEAVED);
+    snd_pcm_hw_params_set_format(pcm_device, params, SND_PCM_FORMAT_S16_LE);
+    snd_pcm_hw_params_set_channels(pcm_device, params, channels);
+    snd_pcm_hw_params_set_rate_near(pcm_device, params, &sample_rate, &dir);
+    snd_pcm_hw_params_set_period_size_near(pcm_device, params, &frames, &dir);
+    snd_pcm_hw_params(pcm_device, params);
+
+    subsystem->pcm_handle = pcm_device;
+
+    sound->sound_data = subsystem;
+    sound->write = alsa_sound_write;
+
+    return true;
+}
+
+#endif /* USE_ALSA */

--- a/src/devices/sound-hda.c
+++ b/src/devices/sound-hda.c
@@ -1,5 +1,5 @@
 /*
-sound-hda.h - HD Audio
+sound-hda.c - HD Audio
 Copyright (C) 2025  David Korenchuk <github.com/epoll-reactor-2>
 
 This Source Code Form is subject to the terms of the Mozilla Public
@@ -11,24 +11,15 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #include "atomics.h"
 #include "compiler.h"
 #include "mem_ops.h"
-#include "rvvm_types.h"
 #include "threading.h"
 #include "spinlock.h"
 #include "utils.h"
-#include <stdio.h>
-#include <unistd.h>
 
 #define SOUND_VENDOR_ID_CMEDIA        0x13f6 // C-Media
 #define SOUND_DEVICE_ID_CMEDIA        0x5011 // CM8888 HDA Controller
 #define SOUND_CLASS_CODE_CMEDIA       0x0403 // Audio device
 
 #define SOUND_HDA_FIFO_SIZE           0x100
-
-// CORB - Command Outbound Ring Buffer
-// CORB verbs: include/sound/hda_verbs.h
-// https://github.com/VendelinSlezak/BleskOS/blob/master/source/drivers/sound/hda.c
-// https://github.com/freebsd/freebsd-src/blob/main/sys/dev/sound/pci/hda/hdac.c
-// https://intel.com/content/dam/www/public/us/en/documents/product-specifications/high-definition-audio-specification.pdf
 
 #define SOUND_HDA_GCAP                0x00 // Global capabilities
 #define SOUND_HDA_VS                  0x02 // 0x02 minor, 0x03 major
@@ -98,18 +89,18 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
                                     | ((SOUND_HDA_PARAM_NO_NSDO &  2) <<  1) \
                                     | ((SOUND_HDA_PARAM_64_BIT  &  1))
 
-#define SOUND_HDA_PARAM_CORBSZCAP     0b0001 /*   8 bytes = 2 entries  */ \
-                                    | 0b0010 /*  64 bytes = 16 entries */ \
-                                    | 0b0100 /* 256 bytes = 32 entries */ \
-                                    | 0b1000
+#define SOUND_HDA_PARAM_CORBSZCAP     1 /*   8 bytes =  2 entries */ \
+                                    | 2 /*  64 bytes = 16 entries */ \
+                                    | 4 /* 256 bytes = 32 entries */ \
+                                    | 8
 
-#define SOUND_HDA_PARAM_RIRBSZCAP     0b0001 /*   16 bytes =   2 entries */ \
-                                    | 0b0010 /*  128 bytes =  16 entries */ \
-                                    | 0b0100 /* 2048 bytes = 256 entries */ \
-                                    | 0b1000
+#define SOUND_HDA_PARAM_RIRBSZCAP     1 /*   16 bytes =   2 entries */ \
+                                    | 2 /*  128 bytes =  16 entries */ \
+                                    | 4 /* 2048 bytes = 256 entries */ \
+                                    | 8
 
-#define SOUND_HDA_PARAM_CORBSIZE      0b10 // 256 bytes = 32 entries
-#define SOUND_HDA_PARAM_RIRBSIZE      0b10 // 2048 bytes = 256 entries
+#define SOUND_HDA_PARAM_CORBSIZE      2 /*  256 bytes =  32 entries */
+#define SOUND_HDA_PARAM_RIRBSIZE      2 /* 2048 bytes = 256 entries */
 
 // Parameters are described in 7.3.4 Parameters
 #define VERB_GET_PARAMETER                               0xF00
@@ -199,6 +190,19 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #define VERB_SET_SUBSYSTEM_ID4                           0x723
 
 #define VERB_GET_CONFIG_DEFAULT                          0xF1C
+#define VERB_GET_CONFIG_DEFAULT_ASSOCIATION_DEFAULT      ( 1 <<  4)
+#define VERB_GET_CONFIG_DEFAULT_COLOR_UNKNOWN            ( 0 << 12)
+#define VERB_GET_CONFIG_DEFAULT_COLOR_BLACK              ( 1 << 12)
+#define VERB_GET_CONFIG_DEFAULT_COLOR_GREY               ( 2 << 12)
+#define VERB_GET_CONFIG_DEFAULT_COLOR_BLUE               ( 3 << 12)
+#define VERB_GET_CONFIG_DEFAULT_COLOR_GREEN              ( 4 << 12)
+#define VERB_GET_CONFIG_DEFAULT_COLOR_RED                ( 5 << 12)
+#define VERB_GET_CONFIG_DEFAULT_COLOR_ORANGE             ( 6 << 12)
+#define VERB_GET_CONFIG_DEFAULT_COLOR_YELLOW             ( 7 << 12)
+#define VERB_GET_CONFIG_DEFAULT_COLOR_PURPLE             ( 8 << 12)
+#define VERB_GET_CONFIG_DEFAULT_COLOR_PINK               ( 9 << 12)
+#define VERB_GET_CONFIG_DEFAULT_COLOR_WHITE              (14 << 12)
+#define VERB_GET_CONFIG_DEFAULT_COLOR_OTHER              (15 << 12)
 #define VERB_GET_CONFIG_DEFAULT_DEVICE_LINE_OUT          ( 0 << 20)
 #define VERB_GET_CONFIG_DEFAULT_DEVICE_SPEAKER           ( 1 << 20)
 #define VERB_GET_CONFIG_DEFAULT_DEVICE_HP_OUT            ( 2 << 20)
@@ -288,68 +292,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #define CODEC_PARAM_GPIO_CNT                             0x11
 #define CODEC_PARAM_VOLUME_KNOB                          0x12
 
-// For debugging purposes. Should I cut my fingers? I don't know.
-static inline const char *sound_param_to_string(int param)
-{
-    switch (param) {
-    case SOUND_HDA_GCAP:          return "SOUND_HDA_GCAP            ";
-    case SOUND_HDA_VS:            return "SOUND_HDA_VS              ";
-    case SOUND_HDA_OUTPAY:        return "SOUND_HDA_OUTPAY          ";
-    case SOUND_HDA_INPAY:         return "SOUND_HDA_INPAY           ";
-    case SOUND_HDA_GLOBAL_CTRL:   return "SOUND_HDA_GLOBAL_CTRL     ";
-    case SOUND_HDA_WAKEEN:        return "SOUND_HDA_WAKEEN          ";
-    case SOUND_HDA_STATESTS:      return "SOUND_HDA_STATESTS        ";
-    case SOUND_HDA_GTS:           return "SOUND_HDA_GTS             ";
-    case SOUND_HDA_OUTSTRMPAY:    return "SOUND_HDA_OUTSTRMPAY      ";
-    case SOUND_HDA_INSTRMPAY:     return "SOUND_HDA_INSTRMPAY       ";
-    case SOUND_HDA_INTR_CTRL:     return "SOUND_HDA_INTR_CTRL       ";
-    case SOUND_HDA_INTSTS:        return "SOUND_HDA_INTSTS          ";
-    case SOUND_HDA_WALL_CLOCK:    return "SOUND_HDA_WALL_CLOCK      ";
-    case SOUND_HDA_STREAM_SYNC:   return "SOUND_HDA_STREAM_SYNC     ";
-    case SOUND_HDA_CORB_LO:       return "SOUND_HDA_CORB_LO         ";
-    case SOUND_HDA_CORB_HI:       return "SOUND_HDA_CORB_HI         ";
-    case SOUND_HDA_CORB_WP:       return "SOUND_HDA_CORB_WP         ";
-    case SOUND_HDA_CORB_RP:       return "SOUND_HDA_CORB_RP         ";
-    case SOUND_HDA_CORB_CTRL:     return "SOUND_HDA_CORB_CTRL       ";
-    case SOUND_HDA_CORB_SIZE:     return "SOUND_HDA_CORB_SIZE       ";
-    case SOUND_HDA_RIRB_LO:       return "SOUND_HDA_RIRB_LO         ";
-    case SOUND_HDA_RIRB_HI:       return "SOUND_HDA_RIRB_HI         ";
-    case SOUND_HDA_RIRB_WP:       return "SOUND_HDA_RIRB_WP         ";
-    case SOUND_HDA_RIRB_INTR_CNT: return "SOUND_HDA_RIRB_INTR_CNT   ";
-    case SOUND_HDA_RIRB_CTRL:     return "SOUND_HDA_RIRB_CTRL       ";
-    case SOUND_HDA_RIRB_STATUS:   return "SOUND_HDA_RIRB_STATUS     ";
-    case SOUND_HDA_RIRB_SIZE:     return "SOUND_HDA_RIRB_SIZE       ";
-    case SOUND_HDA_DMA_LO:        return "SOUND_HDA_DMA_LO          ";
-    case SOUND_HDA_DMA_HI:        return "SOUND_HDA_DMA_HI          ";
-    case SOUND_HDA_ISD0CTL:       return "SOUND_HDA_ISD0CTL         ";
-    case SOUND_HDA_ISD0STS:       return "SOUND_HDA_ISD0STS         ";
-    case SOUND_HDA_ISD0LPIB:      return "SOUND_HDA_ISD0LPIB        ";
-    case SOUND_HDA_ISD0CBL:       return "SOUND_HDA_ISD0CBL         ";
-    case SOUND_HDA_ISD0LVI:       return "SOUND_HDA_ISD0LVI         ";
-    case SOUND_HDA_ISD0FIFOS:     return "SOUND_HDA_ISD0FIFOS       ";
-    case SOUND_HDA_ISD0FMT:       return "SOUND_HDA_ISD0FMT         ";
-    case SOUND_HDA_ISD0BDPL:      return "SOUND_HDA_ISD0BDPL        ";
-    case SOUND_HDA_ISD0BDPU:      return "SOUND_HDA_ISD0BDPU        ";
-    case SOUND_HDA_OSD0CTL:       return "SOUND_HDA_OSD0CTL         ";
-    case SOUND_HDA_OSD0STS:       return "SOUND_HDA_OSD0STS         ";
-    case SOUND_HDA_OSD0LPIB:      return "SOUND_HDA_OSD0LPIB        ";
-    case SOUND_HDA_OSD0CBL:       return "SOUND_HDA_OSD0CBL         ";
-    case SOUND_HDA_OSD0LVI:       return "SOUND_HDA_OSD0LVI         ";
-    case SOUND_HDA_OSD0FIFOS:     return "SOUND_HDA_OSD0FIFOS       ";
-    case SOUND_HDA_OSD0FMT:       return "SOUND_HDA_OSD0FMT         ";
-    case SOUND_HDA_OSD0BDPL:      return "SOUND_HDA_OSD0BDPL        ";
-    case SOUND_HDA_OSD0BDPU:      return "SOUND_HDA_OSD0BDPU        ";
-    default: {
-        static char buf[64];
-        sprintf(buf, "<UNKNOWN> %08x        ", param);
-        return buf;
-    }
-    }
-}
-
-#define hda_info(fmt, ...) rvvm_info("Sound HDA: " fmt, ##__VA_ARGS__)
-
 typedef struct {
+    uint8_t     bdl_lvi;
     uint32_t    bdl_lo;
     uint32_t    bdl_hi;
     uint32_t    bdl_len;
@@ -357,7 +301,7 @@ typedef struct {
     uint8_t     ioce;
     uint8_t     stream;
     uint8_t     channel;
-    atomic_bool running;
+    uint32_t    running;
     uint8_t     fmt;
     uint8_t     status;
     uint8_t     left_gain;
@@ -370,7 +314,7 @@ typedef struct {
     pci_func_t* pci_func;
     spinlock_t  lock;
     uint32_t    gctl;
-    uint32_t    gctl_accept_unsol;
+    uint32_t    intr_ctrl;
     uint32_t    corb_lo;
     uint32_t    corb_hi;
     uint16_t    corb_rp;
@@ -386,6 +330,7 @@ typedef struct {
     uint32_t    power_state;
 
     sound_hda_stream_t stream_output;
+    sound_subsystem_t subsystem;
 } sound_hda_dev_t;
 
 static void sound_hda_remove(rvvm_mmio_dev_t* dev)
@@ -394,7 +339,7 @@ static void sound_hda_remove(rvvm_mmio_dev_t* dev)
 }
 
 static rvvm_mmio_type_t sound_hda_type = {
-    .name = "intel-hda",
+    .name = "intel_hda",
     .remove = sound_hda_remove,
 };
 
@@ -404,8 +349,6 @@ static bool sound_hda_mmio_read(rvvm_mmio_dev_t* dev, void* data, size_t offset,
 
     sound_hda_dev_t *hda = dev->data;
     spin_lock(&hda->lock);
-
-    hda_info("read at %08"PRIx64" %s", (uint64_t) offset, sound_param_to_string(offset));
 
     switch (offset) {
         case SOUND_HDA_GCAP:
@@ -424,62 +367,27 @@ static bool sound_hda_mmio_read(rvvm_mmio_dev_t* dev, void* data, size_t offset,
             hda->gctl |= (1 << 8) | 1; // 1 << 8 is UNSOL
             write_uint32_le(data, hda->gctl);
             break;
-        case SOUND_HDA_WAKEEN:
+        case SOUND_HDA_INTR_CTRL:
+            write_uint32_le(data, hda->intr_ctrl);
             break;
-        case SOUND_HDA_STATESTS:
-            break;
-        case SOUND_HDA_GTS:
-            break;
-        case SOUND_HDA_OUTSTRMPAY:
-            break;
-        case SOUND_HDA_INSTRMPAY:
-            break;
-        case SOUND_HDA_INTR_CTRL: {
-            // Is this repeats configuration in GCAP?
-            uint32_t cmd = 0;
-            cmd |= (0 << 31); // Global interrupt disabled
-            cmd |= (0 << 30); // Controller interrupt disabled
-            cmd |= (1 <<  0); // Input stream 1 enabled
-            cmd |= (1 <<  1); // Input stream 2 enabled
-            cmd |= (1 <<  2); // Output stream 1 enabled
-            cmd |= (1 <<  3); // Output stream 2 enabled
-            write_uint32_le(data, cmd);
-            break;
-        }
         case SOUND_HDA_INTSTS:
-            break;
-        case SOUND_HDA_WALL_CLOCK:
-            break;
-        case SOUND_HDA_STREAM_SYNC:
-            break;
-        case SOUND_HDA_CORB_LO:
-            break;
-        case SOUND_HDA_CORB_HI:
+            // As per specification and to simplify this code,
+            // we assume that interrupt always occured when
+            // guest reads this. Value represent interrupt
+            // on the outptut stream.
+            write_uint32_le(data, 1 << 29);
             break;
         case SOUND_HDA_CORB_WP:
             write_uint16_le(data, hda->corb_wp);
             break;
         case SOUND_HDA_CORB_RP:
-            write_uint16_le(data, hda->corb_rp & 0b11111111);
-            break;
-        case SOUND_HDA_CORB_CTRL:
-            break;
-        case SOUND_HDA_CORB_STATUS:
+            write_uint16_le(data, hda->corb_rp & 0xFF);
             break;
         case SOUND_HDA_CORB_SIZE:
             write_uint8(data, SOUND_HDA_PARAM_CORBSZCAP << 4 | SOUND_HDA_PARAM_CORBSIZE);
             break;
-        case SOUND_HDA_RIRB_LO:
-            break;
-        case SOUND_HDA_RIRB_HI:
-            break;
-        case SOUND_HDA_RIRB_WP: {
-            write_uint16_le(data, hda->rirb_wp & 0b11111111);
-            break;
-        }
-        case SOUND_HDA_RIRB_INTR_CNT:
-            break;
-        case SOUND_HDA_RIRB_CTRL:
+        case SOUND_HDA_RIRB_WP:
+            write_uint16_le(data, hda->rirb_wp & 0xFF);
             break;
         case SOUND_HDA_RIRB_STATUS:
             write_uint8(data, hda->rirb_status & 0xFF);
@@ -487,10 +395,6 @@ static bool sound_hda_mmio_read(rvvm_mmio_dev_t* dev, void* data, size_t offset,
             break;
         case SOUND_HDA_RIRB_SIZE:
             write_uint8(data, SOUND_HDA_PARAM_RIRBSZCAP << 4 | SOUND_HDA_PARAM_RIRBSIZE);
-            break;
-        case SOUND_HDA_DMA_LO:
-            break;
-        case SOUND_HDA_DMA_HI:
             break;
         case SOUND_HDA_OSD0STS: {
             uint8_t cmd = 0;
@@ -513,16 +417,13 @@ static bool sound_hda_mmio_read(rvvm_mmio_dev_t* dev, void* data, size_t offset,
             spin_unlock(&hda->lock);
             return false;
     }
-    spin_unlock(&hda->lock);
 
+    spin_unlock(&hda->lock);
     return true;
 }
 
-static void write_response_to_rirb(sound_hda_dev_t *hda, uint32_t cad, uint32_t response)
+static void sound_hda_write_rirb(sound_hda_dev_t *hda, uint32_t cad, uint32_t response)
 {
-    hda_info("write to RIRB { resp: %u, rp: %08x, wp: %08x}",
-        response, hda->rirb_rp, hda->rirb_wp);
-
     ++hda->rirb_wp;
     hda->rirb_wp %= hda->rirb_size;
 
@@ -540,167 +441,164 @@ static void write_response_to_rirb(sound_hda_dev_t *hda, uint32_t cad, uint32_t 
 }
 
 // NID = 0
-static uint32_t process_codec_root_cmd(uint32_t payload)
+static uint32_t sound_hda_codec_root_cmd(uint32_t payload)
 {
     switch (payload) {
-    case CODEC_PARAM_VENDOR_ID:
-        return SOUND_DEVICE_ID_CMEDIA;
+        case CODEC_PARAM_VENDOR_ID:
+            return SOUND_DEVICE_ID_CMEDIA;
 
-    case CODEC_PARAM_REVISION_ID:
-        return 0xFFFF;
+        case CODEC_PARAM_REVISION_ID:
+            return 0xFFFF;
 
-    case CODEC_PARAM_SUB_NODE_COUNT:
-        return 0x00010001; // 1 Subnode, StartNid = 1
+        case CODEC_PARAM_SUB_NODE_COUNT:
+            return 0x00010001; // 1 Subnode, StartNid = 1
 
-    default:
-        return 0;
+        default:
+            return 0;
     }
 }
 
 // NID = 1
-static uint32_t process_codec_fg_output_cmd(uint32_t payload)
+static uint32_t sound_hda_codec_fg_output_cmd(uint32_t payload)
 {
     switch (payload) {
-    case CODEC_PARAM_SUB_NODE_COUNT:
-        return 0x00020002; // 2 Subnode, StartNid = 2
+        case CODEC_PARAM_SUB_NODE_COUNT:
+            return 0x00020002; // 2 Subnode, StartNid = 2
 
-    case CODEC_PARAM_FUNC_GROUP_TYPE:
-        return CODEC_PARAM_FUNC_GROUP_TYPE_AUDIO;
+        case CODEC_PARAM_FUNC_GROUP_TYPE:
+            return CODEC_PARAM_FUNC_GROUP_TYPE_AUDIO;
 
-    case CODEC_PARAM_SUPP_PCM_SIZE_RATES:
-        return (0x1F << 16) | 0x7FF; // B8 - B32, 8.0 - 192.0kHz
+        case CODEC_PARAM_SUPP_PCM_SIZE_RATES:
+            return (0x1F << 16) | 0x7FF; // B8 - B32, 8.0 - 192.0kHz
 
-    case CODEC_PARAM_SUPP_STREAM_FMTS:
-        return CODEC_PARAM_SUPP_STREAM_FMTS_PCM;
+        case CODEC_PARAM_SUPP_STREAM_FMTS:
+            return CODEC_PARAM_SUPP_STREAM_FMTS_PCM;
 
-    case CODEC_PARAM_SUPP_POWER_STATES:
-        return 0b1111; // D3, D2, D1, D0
+        case CODEC_PARAM_SUPP_POWER_STATES:
+            return 0xF; // D3, D2, D1, D0
 
-    default:
-        return 0;
+        default:
+            return 0;
     }
 }
 
 // NID = 2
-static uint32_t process_codec_output_cmd(uint32_t payload)
+static uint32_t sound_hda_codec_output_cmd(uint32_t payload)
 {
     switch (payload) {
-    case CODEC_PARAM_VENDOR_ID:
-        return SOUND_DEVICE_ID_CMEDIA;
+        case CODEC_PARAM_VENDOR_ID:
+            return SOUND_DEVICE_ID_CMEDIA;
 
-    case CODEC_PARAM_REVISION_ID:
-        return 0xFFFF;
+        case CODEC_PARAM_REVISION_ID:
+            return 0xFFFF;
 
-    case CODEC_PARAM_SUB_NODE_COUNT:
-        return 0x00010001; // 1 Subnode, StartNid = 1
+        case CODEC_PARAM_SUB_NODE_COUNT:
+            return 0x00010001; // 1 Subnode, StartNid = 1
 
-    case CODEC_PARAM_AUDIO_WIDGET_CAPS:
-        return CODEC_PARAM_AUDIO_WIDGET_CAPS_OUTPUT
-             | CODEC_PARAM_AUDIO_WIDGET_CAPS_FORMAT_OVR
-             | CODEC_PARAM_AUDIO_WIDGET_CAPS_AMP_OVR
-             | CODEC_PARAM_AUDIO_WIDGET_CAPS_AMP_OUT
-             | CODEC_PARAM_AUDIO_WIDGET_CAPS_STEREO;
+        case CODEC_PARAM_AUDIO_WIDGET_CAPS:
+            return CODEC_PARAM_AUDIO_WIDGET_CAPS_OUTPUT
+                 | CODEC_PARAM_AUDIO_WIDGET_CAPS_FORMAT_OVR
+                 | CODEC_PARAM_AUDIO_WIDGET_CAPS_AMP_OVR
+                 | CODEC_PARAM_AUDIO_WIDGET_CAPS_AMP_OUT
+                 | CODEC_PARAM_AUDIO_WIDGET_CAPS_STEREO;
 
-    case CODEC_PARAM_SUPP_PCM_SIZE_RATES:
-        return (0x1F << 16) | 0x7FF; // B8 - B32, 8.0 - 192.0kHz
+        case CODEC_PARAM_SUPP_PCM_SIZE_RATES:
+            return (0x1F << 16) | 0x7FF; // B8 - B32, 8.0 - 192.0kHz
 
-    case CODEC_PARAM_SUPP_STREAM_FMTS:
-        return CODEC_PARAM_SUPP_STREAM_FMTS_PCM;
+        case CODEC_PARAM_SUPP_STREAM_FMTS:
+            return CODEC_PARAM_SUPP_STREAM_FMTS_PCM;
 
-    case CODEC_PARAM_OUTPUT_AMP_CAPS:
-        return CODEC_PARAM_OUTPUT_AMP_CAPS_MUTE_CAP
-             | CODEC_PARAM_OUTPUT_AMP_CAPS_STEPSIZE
-             | CODEC_PARAM_OUTPUT_AMP_CAPS_NUMSTEPS
-             | CODEC_PARAM_OUTPUT_AMP_CAPS_OFFSET;
+        case CODEC_PARAM_OUTPUT_AMP_CAPS:
+            return CODEC_PARAM_OUTPUT_AMP_CAPS_MUTE_CAP
+                 | CODEC_PARAM_OUTPUT_AMP_CAPS_STEPSIZE
+                 | CODEC_PARAM_OUTPUT_AMP_CAPS_NUMSTEPS
+                 | CODEC_PARAM_OUTPUT_AMP_CAPS_OFFSET;
 
-    default:
-        return 0;
+        default:
+            return 0;
     }
 }
 
 // NID = 3
-static uint32_t process_codec_pin_output_cmd(uint32_t payload)
+static uint32_t sound_hda_codec_pin_output_cmd(uint32_t payload)
 {
     switch (payload) {
-    case CODEC_PARAM_AUDIO_WIDGET_CAPS:
-        return CODEC_PARAM_AUDIO_WIDGET_CAPS_PIN
-             | CODEC_PARAM_AUDIO_WIDGET_CAPS_CONN_LIST
-             | CODEC_PARAM_AUDIO_WIDGET_CAPS_STEREO;
+        case CODEC_PARAM_AUDIO_WIDGET_CAPS:
+            return CODEC_PARAM_AUDIO_WIDGET_CAPS_PIN
+                 | CODEC_PARAM_AUDIO_WIDGET_CAPS_CONN_LIST
+                 | CODEC_PARAM_AUDIO_WIDGET_CAPS_STEREO;
 
-    case CODEC_PARAM_PIN_CAPS:
-        return CODEC_PARAM_PIN_CAPS_OUTPUT
-             | CODEC_PARAM_PIN_CAPS_PRESENSE_DETECT;
+        case CODEC_PARAM_PIN_CAPS:
+            return CODEC_PARAM_PIN_CAPS_OUTPUT
+                 | CODEC_PARAM_PIN_CAPS_PRESENSE_DETECT;
 
-    case CODEC_PARAM_CONN_LIST_LEN:
-        return 1;
+        case CODEC_PARAM_CONN_LIST_LEN:
+            return 1;
 
-    default:
-        return 0;
+        default:
+            return 0;
     }
 }
 
-#define NODE_ID_ROOT                0 // Root node
-#define NODE_ID_FG_OUTPUT           1 // Output function group
-#define NODE_ID_OUTPUT              2 // Output
-#define NODE_ID_PIN_OUTPUT          3 // Pin output
+#define NODE_ID_ROOT       0 // Root node
+#define NODE_ID_FG_OUTPUT  1 // Output function group
+#define NODE_ID_OUTPUT     2 // Output
+#define NODE_ID_PIN_OUTPUT 3 // Pin output
 
-static uint32_t process_codec_stream_cmd(sound_hda_stream_t *stream, uint32_t nid, uint32_t verb, uint32_t payload)
+static uint32_t sound_hda_codec_stream_cmd(sound_hda_stream_t *stream, uint32_t nid, uint32_t verb, uint32_t payload)
 {
     uint32_t response = 0;
     uint8_t  mute = 0;
     uint8_t  gain = 0;
 
-    hda_info("Stream verb: 0x%0X", verb);
-
     switch (verb) {
-    case VERB_GET_CONV_FMT:
-        response = stream->fmt;
-        break;
-    case VERB_SET_CONV_FMT:
-        stream->fmt = payload;
-        break;
-    case VERB_GET_AMP_GAIN_MUTE:
-        if (payload & VERB_GET_AMP_GAIN_MUTE_LEFT) {
-            response = stream->left_gain | stream->left_mute;
-        }
-
-        if (payload & VERB_GET_AMP_GAIN_MUTE_RIGHT) {
-            response = stream->right_gain | stream->right_mute;
-        }
-
-        break;
-    case VERB_SET_AMP_GAIN_MUTE:
-        mute = VERB_SET_AMP_GAIN_MUTE_MUTE;
-        gain = VERB_SET_AMP_GAIN_MUTE_GAIN_MASK;
-
-        if (payload & VERB_SET_AMP_GAIN_MUTE_LEFT) {
-            stream->left_mute = mute;
-            stream->left_gain = gain;
-        }
-
-        if (payload & VERB_SET_AMP_GAIN_MUTE_RIGHT) {
-            stream->right_mute = mute;
-            stream->right_gain = gain;
-        }
-
-        break;
-    case VERB_GET_CONV_STREAM_CHAN:
-        response = (stream->stream << 4) | stream->channel;
-        break;
-    case VERB_SET_CONV_STREAM_CHAN:
-        stream->channel = payload & 0x0F;
-        stream->stream = (payload >> 4) & 0x0F;
-        hda_info("Stream set channel: %x, stream: %x", stream->channel, stream->stream);
-        break;
-    case VERB_GET_PIN_WIDGET_CTRL:
-        switch (nid) {
-        case NODE_ID_PIN_OUTPUT:
-            response = VERB_GET_PIN_WIDGET_CTRL_OUT_ENABLE;
+        case VERB_GET_CONV_FMT:
+            response = stream->fmt;
             break;
-        }
-        break;
-    default:
-        break;
+        case VERB_SET_CONV_FMT:
+            stream->fmt = payload;
+            break;
+        case VERB_GET_AMP_GAIN_MUTE:
+            if (payload & VERB_GET_AMP_GAIN_MUTE_LEFT) {
+                response = stream->left_gain | stream->left_mute;
+            }
+
+            if (payload & VERB_GET_AMP_GAIN_MUTE_RIGHT) {
+                response = stream->right_gain | stream->right_mute;
+            }
+
+            break;
+        case VERB_SET_AMP_GAIN_MUTE:
+            mute = VERB_SET_AMP_GAIN_MUTE_MUTE;
+            gain = VERB_SET_AMP_GAIN_MUTE_GAIN_MASK;
+
+            if (payload & VERB_SET_AMP_GAIN_MUTE_LEFT) {
+                stream->left_mute = mute;
+                stream->left_gain = gain;
+            }
+
+            if (payload & VERB_SET_AMP_GAIN_MUTE_RIGHT) {
+                stream->right_mute = mute;
+                stream->right_gain = gain;
+            }
+
+            break;
+        case VERB_GET_CONV_STREAM_CHAN:
+            response = (stream->stream << 4) | stream->channel;
+            break;
+        case VERB_SET_CONV_STREAM_CHAN:
+            stream->channel = payload & 0x0F;
+            stream->stream = (payload >> 4) & 0x0F;
+            break;
+        case VERB_GET_PIN_WIDGET_CTRL:
+            switch (nid) {
+            case NODE_ID_PIN_OUTPUT:
+                response = VERB_GET_PIN_WIDGET_CTRL_OUT_ENABLE;
+                break;
+            }
+            break;
+        default:
+            break;
     }
 
     return response;
@@ -711,7 +609,7 @@ static uint32_t process_codec_stream_cmd(sound_hda_stream_t *stream, uint32_t ni
 #define VERB_PARAM_CAD_SHIFT       28
 #define VERB_PARAM_NID_SHIFT       20
 
-static void process_codec_cmd(sound_hda_dev_t *hda, uint32_t cmd)
+static void sound_hda_codec_cmd(sound_hda_dev_t *hda, uint32_t cmd)
 {
     uint8_t cad = 0;
     uint8_t nid = 0;
@@ -719,6 +617,8 @@ static void process_codec_cmd(sound_hda_dev_t *hda, uint32_t cmd)
     uint16_t payload = 0;
     uint32_t response = 0;
 
+    // 4.4.1.5 Other CORB Programming Notes
+    // Zero is valid CORB command.
     if (cmd == 0)
         return;
 
@@ -734,180 +634,128 @@ static void process_codec_cmd(sound_hda_dev_t *hda, uint32_t cmd)
     }
 
     switch (verb) {
-    case VERB_GET_PARAMETER:
-        // We define NID count and start indices in CODEC_PARAM_SUB_NODE_COUNT
-        switch (nid) {
-        case NODE_ID_ROOT:
-            response = process_codec_root_cmd(payload);
-            break;
-        case NODE_ID_FG_OUTPUT:
-            response = process_codec_fg_output_cmd(payload);
-            break;
-        case NODE_ID_OUTPUT:
-            response = process_codec_output_cmd(payload);
-            break;
-        case NODE_ID_PIN_OUTPUT:
-            response = process_codec_pin_output_cmd(payload);
-            break;
-        }
+        case VERB_GET_PARAMETER:
+            // We define NID count and start indices in CODEC_PARAM_SUB_NODE_COUNT
+            switch (nid) {
+            case NODE_ID_ROOT:
+                response = sound_hda_codec_root_cmd(payload);
+                break;
+            case NODE_ID_FG_OUTPUT:
+                response = sound_hda_codec_fg_output_cmd(payload);
+                break;
+            case NODE_ID_OUTPUT:
+                response = sound_hda_codec_output_cmd(payload);
+                break;
+            case NODE_ID_PIN_OUTPUT:
+                response = sound_hda_codec_pin_output_cmd(payload);
+                break;
+            }
 
-        break;
-    case VERB_GET_SUBSYSTEM_ID:
-        response = (SOUND_DEVICE_ID_CMEDIA << 16) | 1;
-        break;
-    case VERB_SET_POWER_STATE:
-        hda->power_state = payload;
-        response = 0;
-        break;
-    case VERB_GET_POWER_STATE:
-        //         PS-Set              PS-Act
-        response = hda->power_state | (hda->power_state << 4);
-        break;
-    case VERB_GET_PIN_WIDGET_CTRL:
-        response |= VERB_GET_PIN_WIDGET_CTRL_OUT_ENABLE;
-        break;
-    case VERB_GET_PIN_SENSE:
-        response = VERB_GET_PIN_SENSE_PRESENSE_PLUGGED;
-        break;
-    case VERB_GET_CONN_LIST_ENTRY:
-        response = NODE_ID_OUTPUT;
-        break;
-    case VERB_GET_CONFIG_DEFAULT:
-        response |= VERB_GET_CONFIG_DEFAULT_CONNECTIVITY_JACK
-                 |  VERB_GET_CONFIG_DEFAULT_DEVICE_LINE_OUT
-                 |  (1 <<  4)  // CONFIG_DEFAULT_ASSOCIATION_SHIFT. ???
-                 |  (1 << 12); // CONFIG_DEFAULT_COLOR_SHIFT. ???
-        break;
-    default:
-        switch (nid) {
-        case NODE_ID_OUTPUT:
-            response = process_codec_stream_cmd(&hda->stream_output, nid, verb, payload);
             break;
-        }
-        break;
+        case VERB_GET_SUBSYSTEM_ID:
+            response = (SOUND_DEVICE_ID_CMEDIA << 16) | 1;
+            break;
+        case VERB_SET_POWER_STATE:
+            hda->power_state = payload;
+            response = 0;
+            break;
+        case VERB_GET_POWER_STATE:
+            //         PS-Set              PS-Act
+            response = hda->power_state | (hda->power_state << 4);
+            break;
+        case VERB_GET_PIN_WIDGET_CTRL:
+            response = VERB_GET_PIN_WIDGET_CTRL_OUT_ENABLE;
+            break;
+        case VERB_GET_PIN_SENSE:
+            response = VERB_GET_PIN_SENSE_PRESENSE_PLUGGED;
+            break;
+        case VERB_GET_CONN_LIST_ENTRY:
+            response = NODE_ID_OUTPUT;
+            break;
+        case VERB_GET_CONFIG_DEFAULT:
+            response = VERB_GET_CONFIG_DEFAULT_CONNECTIVITY_JACK
+                     | VERB_GET_CONFIG_DEFAULT_DEVICE_LINE_OUT
+                     | VERB_GET_CONFIG_DEFAULT_ASSOCIATION_DEFAULT
+                     | VERB_GET_CONFIG_DEFAULT_COLOR_ORANGE;
+            break;
+        default:
+            switch (nid) {
+            case NODE_ID_OUTPUT:
+                response = sound_hda_codec_stream_cmd(&hda->stream_output, nid, verb, payload);
+                break;
+            }
+            break;
     }
 
-    write_response_to_rirb(hda, cad, response);
+    sound_hda_write_rirb(hda, cad, response);
 }
 
-// Ugly.
-static void* stream_worker(void *arg)
+static void *sound_hda_stream_worker(void *arg)
 {
-    sound_hda_dev_t *hda = (sound_hda_dev_t *) arg;
+    sound_hda_dev_t *hda = arg;
     sound_hda_stream_t *stream = &hda->stream_output;
 
-    uint32_t should_generate_ioc = 0;
+    uint32_t total = stream->bdl_lvi + 1;
+    uint64_t *dma = pci_get_dma_ptr(hda->pci_func, stream->bdl_lo, stream->bdl_len);
+    while (atomic_load_uint32_relax(&stream->running)) {
+        for (uint32_t i = 0; i < total; ++i) {
+            uint64_t *bdle = &dma[i * 2];
+            uint64_t addr = bdle[0];
+            uint32_t len  = bdle[1] & 0xFFFFFFFF;
+            uint8_t  ioc  = bdle[1] >> 32 & 1;
 
-    while (atomic_load(&stream->running)) {
-        uint64_t *bdl = pci_get_dma_ptr(
-            hda->pci_func, (rvvm_addr_t) stream->bdl_lo, stream->bdl_len);
-
-        uint32_t num_entries = hda->stream_output.bdl_len / 16;
-
-        for (uint32_t i = 0; i < num_entries; ++i) {
-            uint64_t addr =  bdl[i * 2 + 0];
-            uint32_t len  =  bdl[i * 2 + 1] & 0xFFFFFFFF;
-            uint8_t  ioc  = (bdl[i * 2 + 1] >> 32) & 1;
-
-            if (addr == 0 || len == 0)
-                break;
-
-            if (ioc) {
-                should_generate_ioc = 1;
-            }
-
-            uint8_t *pcm_data = pci_get_dma_ptr(hda->pci_func, (rvvm_addr_t) addr, len);
-            hda_info("%2d: PCM %02x %02x %02x %02x %02x %02x %02x %02x",
-                i,
-                pcm_data[ 3], pcm_data[ 7], pcm_data[11], pcm_data[15],
-                pcm_data[19], pcm_data[23], pcm_data[27], pcm_data[31]
-            );
-
+#ifdef USE_ALSA
+            void *pcm = pci_get_dma_ptr(hda->pci_func, addr, len);
+            hda->subsystem.write(&hda->subsystem, pcm, len);
+#else
+            // TODO: Stub backend or don't compile this file if no
+            //       sound compilation option?
+            UNUSED(addr);
+#endif
             stream->lpib += len;
-
-            // Wrap LPIB if we reach the buffer limit (for streams longer that BDL length)
-            if (stream->lpib >= stream->bdl_len) {
+            // If stream longer than BDL length, reset LPIB.
+            if (stream->lpib >= stream->bdl_len)
                 stream->lpib = 0;
-            }
-
-            // Optionally if IOC enabled we could notify the guest
-
-            // If this is a short stream, stop when we reach the total data length
-            if (stream->bdl_len > 0 && stream->lpib >= stream->bdl_len) {
-                atomic_store(&stream->running, 0);
-            }
-        }
-
-        if (should_generate_ioc) {
-            should_generate_ioc = 0;
-            pci_send_irq(hda->pci_func, 0);
+            // When LPIB goes over BDL length, we are done.
+            if (stream->bdl_len > 0 && stream->lpib > stream->bdl_len)
+                atomic_store_uint32_relax(&stream->running, 0);
+            if (ioc)
+                pci_send_irq(hda->pci_func, 0);
         }
     }
 
     return NULL;
 }
 
-static void process_output_stream_ctl(sound_hda_dev_t *hda, uint32_t cmd)
+static void sound_hda_output_stream_ctl(sound_hda_dev_t *hda, uint32_t cmd)
 {
- // uint8_t strm   = (cmd >> 20) & 0b1111;
- // uint8_t dir    = (cmd >> 19) & 0b1;
- // uint8_t tp     = (cmd >> 18) & 0b1;
- // uint8_t stripe = (cmd >> 16) & 0b11;
- // uint8_t deie   = (cmd >>  4) & 0b1;
- // uint8_t feie   = (cmd >>  3) & 0b1;
-    uint8_t ioce   = (cmd >>  2) & 0b1;
-    uint8_t run    = (cmd >>  1) & 0b1; // Corresponding SSYNC bit?
- // uint8_t reset  = (cmd >>  0) & 0b1;
+    uint8_t ioce = (cmd >> 2) & 1;
+    uint8_t run  = (cmd >> 1) & 1;
 
     sound_hda_stream_t *stream = &hda->stream_output;
     stream->ioce = ioce;
 
     if (run) {
-        if (!atomic_swap_uint32_ex(&hda->stream_output.running, 1, ATOMIC_RELAXED)) {
-            hda_info("Starting stream");
-            thread_create_task(stream_worker, hda);
-        }
+        atomic_store_uint32_relax(&stream->running, 1);
+        thread_create_task(sound_hda_stream_worker, hda);
     } else {
-        if (!atomic_swap_uint32_ex(&hda->stream_output.running, 0, ATOMIC_RELAXED)) {
-            hda_info("Stopping stream");
-        }
+        atomic_store_uint32_relax(&stream->running, 0);
     }
 }
 
 static bool sound_hda_mmio_write(rvvm_mmio_dev_t* dev, void* data, size_t offset, uint8_t size)
 {
-    UNUSED(dev);
-    UNUSED(data);
-    UNUSED(offset);
     UNUSED(size);
 
     sound_hda_dev_t *hda = dev->data;
-    UNUSED(hda);
     spin_lock(&hda->lock);
 
-    hda_info("write at %08"PRIx64" %s: %04x", (uint64_t) offset, sound_param_to_string(offset), read_uint32_le(data));
-
     switch (offset) {
-        /* No SOUND_HDA_GCAP */
-        /* No SOUND_HDA_VS */
-        /* No SOUND_HDA_RIRB_SIZE */
-
         case SOUND_HDA_GLOBAL_CTRL:
             hda->gctl = read_uint32_le(data);
-
-            if (hda->gctl & 0b00100000000)
-                hda->gctl_accept_unsol = 1;
-
-            break;
-        case SOUND_HDA_WAKEEN:
-            break;
-        case SOUND_HDA_STATESTS:
-            break;
-        case SOUND_HDA_GTS:
             break;
         case SOUND_HDA_INTR_CTRL:
-            break;
-        case SOUND_HDA_STREAM_SYNC:
+            hda->intr_ctrl = read_uint32_le(data);
             break;
         case SOUND_HDA_CORB_LO:
             hda->corb_lo = read_uint32_le(data);
@@ -916,43 +764,30 @@ static bool sound_hda_mmio_write(rvvm_mmio_dev_t* dev, void* data, size_t offset
             hda->corb_hi = read_uint32_le(data);
             break;
         case SOUND_HDA_CORB_WP: {
-            hda->corb_wp = read_uint16_le(data) & 0b1111111;
+            hda->corb_wp = read_uint16_le(data) & 0x7F;
             uint32_t *cmd = pci_get_dma_ptr(
                 hda->pci_func,
                 (rvvm_addr_t) hda->corb_lo + hda->corb_wp * 4,
                 4
             );
-            process_codec_cmd(hda, *cmd);
+            sound_hda_codec_cmd(hda, *cmd);
             break;
         }
         case SOUND_HDA_CORB_RP: {
             uint16_t cmd = read_uint16_le(data);
-            if (cmd & 0x8000) {
+            if (cmd & 0x8000)
                 hda->corb_rp = 0;
-                hda_info("CORB RP is reset");
-            } else {
-                hda->corb_rp = cmd & 0b1111111;
-                hda_info("CORB RP set to %04x", hda->corb_rp);
-            }
-            break;
-        }
-        case SOUND_HDA_CORB_CTRL: {
-            uint8_t cmd = read_uint8(data);
-            if (cmd & 2)
-                { } // CORB start
             else
-                { } // CORB stop
+                hda->corb_rp = cmd & 0x7F;
             break;
         }
-        case SOUND_HDA_CORB_STATUS:
-            break;
         case SOUND_HDA_CORB_SIZE: {
             uint8_t cmd = read_uint8(data);
-            switch (cmd & 0b11) {
-            case 0b00: hda->corb_size =    8; break;
-            case 0b01: hda->corb_size =   64; break;
-            case 0b10: hda->corb_size = 1024; break;
-            case 0b11: /* Reserved */         break;
+            switch (cmd & 3) {
+            case 0: hda->corb_size =    8; break;
+            case 1: hda->corb_size =   64; break;
+            case 2: hda->corb_size = 1024; break;
+            case 3: /* Reserved */         break;
             }
             break;
         }
@@ -967,30 +802,14 @@ static bool sound_hda_mmio_write(rvvm_mmio_dev_t* dev, void* data, size_t offset
             if (cmd & 0x8000)
                 hda->rirb_wp = 0;
             else
-                hda->rirb_wp = cmd & 0b11111111;
+                hda->rirb_wp = cmd & 0xFF;
             break;
         }
-        case SOUND_HDA_RIRB_INTR_CNT: {
+        case SOUND_HDA_RIRB_INTR_CNT:
             hda->rirb_cnt = read_uint16_le(data);
             break;
-        }
-        case SOUND_HDA_RIRB_CTRL: {
-            uint8_t cmd = read_uint8(data);
-            if (cmd & 1)
-                hda_info("RIRB enable response interrupt");
-            else
-                hda_info("RIRB disable responce interrupt");
-
-            if (cmd & 2)
-                hda_info("RIRB DMA enable");
-            else
-                hda_info("RIRB DMA stop");
-
-            break;
-        }
         case SOUND_HDA_RIRB_STATUS: {
             uint8_t cmd = read_uint8(data);
-            hda_info("RIRB status: %02x", cmd);
 
             if (cmd & 0x01)
                 hda->rirb_status &= ~0x1;
@@ -1002,30 +821,23 @@ static bool sound_hda_mmio_write(rvvm_mmio_dev_t* dev, void* data, size_t offset
         }
         case SOUND_HDA_RIRB_SIZE: {
             uint8_t cmd = read_uint8(data);
-            switch (cmd & 0b11) {
-            case 0b00: hda->rirb_size =   16; break;
-            case 0b01: hda->rirb_size =  128; break;
-            case 0b10: hda->rirb_size = 2048; break;
-            case 0b11: /* Reserved */         break;
+            switch (cmd & 3) {
+            case 0: hda->rirb_size =   16; break;
+            case 1: hda->rirb_size =  128; break;
+            case 2: hda->rirb_size = 2048; break;
+            case 3: /* Reserved */         break;
             }
-            hda_info("RIRB size: %d", hda->rirb_size);
             break;
         }
-        case SOUND_HDA_DMA_LO:
-            break;
-        case SOUND_HDA_DMA_HI:
-            break;
         case SOUND_HDA_OSD0CTL:
-            process_output_stream_ctl(hda, read_uint32_le(data));
+            sound_hda_output_stream_ctl(hda, read_uint32_le(data));
             break;
         case SOUND_HDA_OSD0STS: {
             uint8_t cmd = read_uint8(data);
 
-            uint8_t bcis  = (cmd >> 2) & 0b1;
-            uint8_t fifoe = (cmd >> 3) & 0b1;
-            uint8_t dese  = (cmd >> 4) & 0b1;
-
-            hda_info("Write SOUND_HDA_OSD0STS: %02x", cmd);
+            uint8_t bcis  = (cmd >> 2) & 1;
+            uint8_t fifoe = (cmd >> 3) & 1;
+            uint8_t dese  = (cmd >> 4) & 1;
 
             if (bcis)
                 hda->stream_output.status &= ~0x04;
@@ -1038,36 +850,16 @@ static bool sound_hda_mmio_write(rvvm_mmio_dev_t* dev, void* data, size_t offset
 
             break;
         }
-        case SOUND_HDA_OSD0LPIB:
+        case SOUND_HDA_OSD0CBL:
+            hda->stream_output.bdl_len = read_uint32_le(data);
             break;
-        case SOUND_HDA_OSD0CBL: {
-            uint32_t cmd = read_uint32_le(data);
-            hda->stream_output.bdl_len = cmd;
-            hda_info("BDL length set to: %08x", cmd);
-            hda_info("BDL length set to: %08x", hda->stream_output.bdl_len);
-            break;
-        }
         case SOUND_HDA_OSD0LVI:
+            hda->stream_output.bdl_lvi = read_uint32_le(data);
             break;
-        case SOUND_HDA_OSD0FIFOS:
+        case SOUND_HDA_OSD0FMT:
+            // Maybe useful, but guest already plays sound
+            // with different sample rates correctly.
             break;
-        case SOUND_HDA_OSD0FMT: {
-            uint16_t cmd = read_uint16_le(data);
-            hda_info("OSD0FMT: %04x", cmd);
-
-            uint8_t base = (cmd >> 14) & 0b0001; // 14
-            uint8_t mult = (cmd >> 11) & 0b0111; // 13:11
-            uint8_t div  = (cmd >>  8) & 0b0111; // 10:8
-            uint8_t bits = (cmd >>  4) & 0b0111; // 6:4
-            uint8_t chan = (cmd >>  0) & 0b1111; // 3:0
-
-            hda_info("OSD0FMT base: %04x", base);
-            hda_info("OSD0FMT mult: %04x", mult);
-            hda_info("OSD0FMT div:  %04x", div);
-            hda_info("OSD0FMT bits: %04x", bits);
-            hda_info("OSD0FMT chan: %04x", chan);
-            break;
-        }
         case SOUND_HDA_OSD0BDPL:
             hda->stream_output.bdl_lo = read_uint32_le(data);
             break;
@@ -1080,32 +872,13 @@ static bool sound_hda_mmio_write(rvvm_mmio_dev_t* dev, void* data, size_t offset
     }
 
     spin_unlock(&hda->lock);
-
     return true;
 }
 
-PUBLIC pci_dev_t* sound_hda_init(pci_bus_t* pci_bus)
+PUBLIC pci_dev_t *sound_hda_init(pci_bus_t *pci_bus)
 {
     sound_hda_dev_t *sound_hda = safe_new_obj(sound_hda_dev_t);
 
-#if 0 /* Intel HDA */
-    pci_func_desc_t sound_hda_desc = {
-        .vendor_id  = 0x8086, // Intel
-        .device_id  = 0x2668, // HDA Controller
-        .class_code = 0x0403, // Audio device
-        .prog_if    = 0x00,
-        .irq_pin    = PCI_IRQ_PIN_INTA,
-        .bar[0] = {
-            .size        = 0x1000,
-            .min_op_size = 4,
-            .max_op_size = 4,
-            .read        = sound_hda_mmio_read,
-            .write       = sound_hda_mmio_write,
-            .data        = sound_hda,
-            .type        = &sound_hda_type
-        },
-    };
-#else /* C-Media */
     pci_func_desc_t sound_hda_desc = {
         .vendor_id  = SOUND_VENDOR_ID_CMEDIA,
         .device_id  = SOUND_DEVICE_ID_CMEDIA,
@@ -1122,18 +895,20 @@ PUBLIC pci_dev_t* sound_hda_init(pci_bus_t* pci_bus)
             .type        = &sound_hda_type
         },
     };
-#endif
 
-    pci_dev_t* pci_dev = pci_attach_func(pci_bus, &sound_hda_desc);
-    if (pci_dev) {
-        // Successfully plugged in
+    pci_dev_t *pci_dev = pci_attach_func(pci_bus, &sound_hda_desc);
+    if (pci_dev)
         sound_hda->pci_func = pci_get_device_func(pci_dev, 0);
-    }
+
+#ifdef USE_ALSA
+    if (!alsa_sound_init(&sound_hda->subsystem))
+        return NULL;
+#endif
 
     return pci_dev;
 }
 
-PUBLIC pci_dev_t* sound_hda_init_auto(rvvm_machine_t* machine)
+PUBLIC pci_dev_t *sound_hda_init_auto(rvvm_machine_t *machine)
 {
     return sound_hda_init(rvvm_get_pci_bus(machine));
 }

--- a/src/devices/sound-hda.h
+++ b/src/devices/sound-hda.h
@@ -13,6 +13,16 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #include "rvvmlib.h"
 #include "pci-bus.h"
 
+typedef struct sound_subsystem_t sound_subsystem_t;
+
+struct sound_subsystem_t {
+    void *sound_data;
+    void (*write)(sound_subsystem_t *subsystem, void *data, size_t size);
+};
+
+// Internal use
+bool alsa_sound_init(sound_subsystem_t *sound);
+
 PUBLIC pci_dev_t* sound_hda_init(pci_bus_t* pci_bus);
 PUBLIC pci_dev_t* sound_hda_init_auto(rvvm_machine_t* machine);
 

--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,7 @@ Copyright (C) 2021  LekKit <github.com/LekKit>
                     Mr0maks <mr.maks0443@gmail.com>
                     KotB <github.com/0xCatPKG>
                     fish4terrisa-MSDSM <fish4terrisa@fishinix.eu.org>
+                    David Korenchuk <github.com/epoll-reactor-2>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -39,6 +40,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "devices/riscv-plic.h"
 #include "devices/rtc-goldfish.h"
 #include "devices/rtl8169.h"
+#include "devices/sound-hda.h"
 #include "devices/syscon.h"
 #include "devices/usb-xhci.h"
 
@@ -100,6 +102,7 @@ static void rvvm_print_help(void)
         "    -nvme       ...  Explicitly attach storage image as NVMe device\n"
         "    -ata        ...  Explicitly attach storage image as ATA (IDE) device\n"
         "    -nogui           Disable display GUI\n"
+        "    -nosound         Disable sound support\n"
         "    -nonet           Disable networking\n"
         "    -serial     ...  Add more serial ports (Via pty/pipe path), or null\n"
         "    -dtb        ...  Pass custom Device Tree Blob to the machine\n"
@@ -262,6 +265,10 @@ static int rvvm_cli_main(int argc, char** argv)
 
     if (!rvvm_has_arg("nogui") && !rvvm_has_arg("res")) {
         gui_window_init_auto(machine, 640, 480);
+    }
+
+    if (!rvvm_has_arg("nosound")) {
+        sound_hda_init_auto(machine);
     }
 
     tap_dev_t* tap = NULL;


### PR DESCRIPTION
- HDA stream logic verified and works correctly.
- Sound propagated to host.
- **Note:** Volume knob is not handled to don't complicate device even more. Volume of the RVVM sound can be changed from the host.
- **Note:** No headphones and other non-standard output devices inside the VM. All sound should be played into default output device.