### PR TITLE
sound: Overhaul HDA stream path and ALSA backend

### DIFF
--- a/src/devices/alsa.c
+++ b/src/devices/alsa.c
@@ -61,8 +61,41 @@ static void alsa_sound_write(sound_subsystem_t *subsystem, void *data, size_t si
 {
     alsa_subsystem_t *alsa = subsystem->sound_data;
 
-    if (snd_pcm_writei(alsa->pcm_handle, data, size / 2) == -EPIPE)
-        snd_pcm_prepare(alsa->pcm_handle);
+    // The previous version called snd_pcm_writei exactly once and
+    // dropped whatever didn't land: on xrun (-EPIPE) it prepared the
+    // PCM but skipped re-writing the chunk; on a positive short return
+    // it ignored the tail; on -EINTR it also dropped. Each lost chunk
+    // is an audible click/crackle.
+    //
+    // Loop until every frame is delivered. size is in bytes and we
+    // always feed mono 16-bit, so one frame = 2 bytes. Bail on
+    // unrecoverable errors after a handful of retries so a disconnected
+    // device doesn't spin us forever.
+    int16_t *buf = (int16_t*)data;
+    snd_pcm_uframes_t remaining = size / 2;
+    int xrun_retries = 4;
+
+    while (remaining > 0) {
+        snd_pcm_sframes_t n = snd_pcm_writei(alsa->pcm_handle, buf, remaining);
+        if (n < 0) {
+            if (n == -EAGAIN || n == -EINTR) {
+                // Spurious short-wake; try again with the same data.
+                continue;
+            }
+            if (n == -EPIPE || n == -ESTRPIPE) {
+                // Xrun / suspend. Reset the PCM and retry the chunk.
+                // -ESTRPIPE means suspended — resume would be ideal but
+                // prepare is enough to get us back to a writable state.
+                if (--xrun_retries < 0) return;
+                snd_pcm_prepare(alsa->pcm_handle);
+                continue;
+            }
+            // Unrecoverable (EBADFD, ENODEV, ...) — give up this chunk.
+            return;
+        }
+        buf       += n;     // int16_t* step = one sample per element
+        remaining -= n;
+    }
 }
 
 static bool alsa_load_symbols(void)

--- a/src/devices/alsa.c
+++ b/src/devices/alsa.c
@@ -29,6 +29,7 @@ ASOUND_DLIB_SYM(snd_pcm_hw_params_set_format)
 ASOUND_DLIB_SYM(snd_pcm_hw_params_set_channels)
 ASOUND_DLIB_SYM(snd_pcm_hw_params_set_rate_near)
 ASOUND_DLIB_SYM(snd_pcm_hw_params_set_period_size_near)
+ASOUND_DLIB_SYM(snd_pcm_hw_params_set_buffer_size_near)
 ASOUND_DLIB_SYM(snd_pcm_hw_params)
 ASOUND_DLIB_SYM(snd_pcm_writei)
 ASOUND_DLIB_SYM(snd_pcm_prepare)
@@ -44,6 +45,7 @@ ASOUND_DLIB_SYM(snd_pcm_hw_params_free)
 #define snd_pcm_hw_params_set_channels snd_pcm_hw_params_set_channels_dlib
 #define snd_pcm_hw_params_set_rate_near snd_pcm_hw_params_set_rate_near_dlib
 #define snd_pcm_hw_params_set_period_size_near snd_pcm_hw_params_set_period_size_near_dlib
+#define snd_pcm_hw_params_set_buffer_size_near snd_pcm_hw_params_set_buffer_size_near_dlib
 #define snd_pcm_hw_params snd_pcm_hw_params_dlib
 #define snd_pcm_writei snd_pcm_writei_dlib
 #define snd_pcm_prepare snd_pcm_prepare_dlib
@@ -87,6 +89,7 @@ do { \
     ASOUND_DLIB_RESOLVE(libasound, snd_pcm_hw_params_set_channels);
     ASOUND_DLIB_RESOLVE(libasound, snd_pcm_hw_params_set_rate_near);
     ASOUND_DLIB_RESOLVE(libasound, snd_pcm_hw_params_set_period_size_near);
+    ASOUND_DLIB_RESOLVE(libasound, snd_pcm_hw_params_set_buffer_size_near);
     ASOUND_DLIB_RESOLVE(libasound, snd_pcm_hw_params);
     ASOUND_DLIB_RESOLVE(libasound, snd_pcm_writei);
     ASOUND_DLIB_RESOLVE(libasound, snd_pcm_prepare);
@@ -116,9 +119,24 @@ bool alsa_sound_init(sound_subsystem_t *sound)
 
     snd_pcm_t *pcm_device = subsystem->pcm_handle;
     snd_pcm_hw_params_t *params = NULL;
-    unsigned int sample_rate = 192000;
+    // Match the HDA codec's advertised format (48 kHz mono 16-bit in
+    // sound-hda.c's CODEC_PARAM_SUPP_PCM_SIZE_RATES). Opening the host
+    // PCM at 192 kHz while the codec feeds 48 kHz streams plays audio
+    // 4× fast → two octaves up.
+    unsigned int sample_rate = 48000;
     int channels = 1;
-    snd_pcm_uframes_t frames = 128;
+    // Host PCM latency. The guest runs its own ALSA buffer on top of the
+    // emulated HDA DMA BDL — that's what user-space apps size via
+    // snd_pcm_hw_params on the guest. These numbers only control the
+    // host-side PipeWire/ALSA ring the emulator feeds into.
+    //
+    // 128 frames / 2.67 ms was too tight: a single host scheduling hiccup
+    // xruns PipeWire and mpg123's write returns short (3400 of 4608) as
+    // back-pressure propagates. 960-frame periods (20 ms) with a 4×
+    // buffer (80 ms total) give PipeWire enough slack to ride out jitter
+    // without noticeable user-facing latency.
+    snd_pcm_uframes_t period_frames = 960;
+    snd_pcm_uframes_t buffer_frames = 3840;
     int dir = 0;
 
     snd_pcm_hw_params_malloc(&params);
@@ -128,7 +146,8 @@ bool alsa_sound_init(sound_subsystem_t *sound)
     snd_pcm_hw_params_set_format(pcm_device, params, SND_PCM_FORMAT_S16_LE);
     snd_pcm_hw_params_set_channels(pcm_device, params, channels);
     snd_pcm_hw_params_set_rate_near(pcm_device, params, &sample_rate, &dir);
-    snd_pcm_hw_params_set_period_size_near(pcm_device, params, &frames, &dir);
+    snd_pcm_hw_params_set_period_size_near(pcm_device, params, &period_frames, &dir);
+    snd_pcm_hw_params_set_buffer_size_near(pcm_device, params, &buffer_frames);
     snd_pcm_hw_params(pcm_device, params);
 
     subsystem->pcm_handle = pcm_device;

--- a/src/devices/sound-hda.c
+++ b/src/devices/sound-hda.c
@@ -350,11 +350,9 @@ static void sound_hda_remove(rvvm_mmio_dev_t* dev)
     sound_hda_dev_t *hda = dev->data;
     if (hda != NULL) {
         atomic_store_uint32_relax(&hda->stream_output.running, 0);
-        // A BDL entry at 48 kHz × 2 bytes is typically 256-4096 bytes =
-        // ~3-43 ms of wall-clock per iteration under the new pacing loop.
-        // 20 ms is enough for the worker to notice the flag before the
-        // next iteration in the common (small-period) case; the worst-
-        // case long-period still exits at the top of the next loop.
+        // The HDA stream period is 128 frames at 192 kHz = ~667 µs wall.
+        // 20 ms of sleep is 30x that — comfortably long enough for the
+        // worker to finish its current iteration.
         sleep_ms(20);
     }
 }
@@ -796,15 +794,21 @@ static void *sound_hda_stream_worker(void *arg)
             uint32_t len  = bdle[1] & 0xFFFFFFFF;
             uint8_t  ioc  = bdle[1] >> 32 & 1;
 
+            // Dispatch PCM to the configured host-side backend. If no backend
+            // was installed at init time (neither a compile-time USE_ALSA nor
+            // a caller-supplied write_fn via sound_hda_init_ex), the HDA
+            // device enumerates on the PCI bus but this path is a no-op —
+            // the guest sees a working device and the LPIB counter advances
+            // so its driver doesn't stall, but PCM data is silently dropped.
+            //
             // Backend contract: always receives MONO 16-bit LE at the
             // stream's configured rate. If the guest driver configured a
             // multi-channel stream (Linux's HDA code likes stereo even
             // when the codec widget advertises mono capability), we
-            // downmix here by averaging channels — keeps the backend's
-            // job simple and the pacing math below stays 1:1 with the
-            // bytes it sees.
-#ifdef USE_ALSA
-            {
+            // downmix here by averaging channels. Keeps backends simple
+            // (they don't need to know channel count) and the pacing
+            // math below stays 1:1 with the bytes they see.
+            if (hda->subsystem.write != NULL) {
                 void *pcm = pci_get_dma_ptr(hda->pci_func, addr, len);
                 if (channels == 1 || pcm == NULL) {
                     hda->subsystem.write(&hda->subsystem, pcm, len);
@@ -831,15 +835,13 @@ static void *sound_hda_stream_worker(void *arg)
                         bytes_emitted += chunk_frames * 2;
                     }
                 } else {
-                    // Rare: non-16-bit multi-channel. Pass raw.
+                    // Rare: non-16-bit multi-channel. Pass raw; backends
+                    // that care can parse stream->fmt from the caller.
                     hda->subsystem.write(&hda->subsystem, pcm, len);
                 }
+            } else {
+                UNUSED(addr);
             }
-#else
-            // No compile-time backend: LPIB still advances (paced below)
-            // so the guest's HDA driver doesn't stall, but PCM is dropped.
-            UNUSED(addr);
-#endif
 
             // Wall-clock pacing. Compute the ideal elapsed time for the
             // bytes we've emitted so far and sleep the difference.
@@ -1033,7 +1035,29 @@ static bool sound_hda_mmio_write(rvvm_mmio_dev_t* dev, void* data, size_t offset
     return true;
 }
 
-PUBLIC pci_dev_t *sound_hda_init(pci_bus_t *pci_bus)
+/*
+ * Bridge struct stored in sound_subsystem_t.sound_data when a caller-supplied
+ * backend is installed via sound_hda_init_ex. Adapts the public two-argument
+ * callback to the subsystem's three-argument shape. Freed... never. The HDA
+ * device itself is leaked on machine destruction today (see sound_hda_remove),
+ * so this follows the same lifecycle.
+ */
+typedef struct {
+    sound_hda_backend_write_fn user_fn;
+    void                       *user_data;
+} sound_hda_backend_bridge_t;
+
+static void sound_hda_backend_bridge_write(sound_subsystem_t *sub, void *data, size_t size)
+{
+    sound_hda_backend_bridge_t *bridge = (sound_hda_backend_bridge_t *)sub->sound_data;
+    if (bridge != NULL && bridge->user_fn != NULL) {
+        bridge->user_fn(bridge->user_data, data, size);
+    }
+}
+
+PUBLIC pci_dev_t *sound_hda_init_ex(pci_bus_t *pci_bus,
+                                    sound_hda_backend_write_fn write_fn,
+                                    void *user_data)
 {
     sound_hda_dev_t *sound_hda = safe_new_obj(sound_hda_dev_t);
 
@@ -1058,12 +1082,39 @@ PUBLIC pci_dev_t *sound_hda_init(pci_bus_t *pci_bus)
     if (pci_dev)
         sound_hda->pci_func = pci_get_device_func(pci_dev, 0);
 
+    // Backend selection priority:
+    //   1. Caller-supplied write_fn (via sound_hda_init_ex) — skip the
+    //      compile-time default. Used by embedders that want to route
+    //      audio somewhere other than the host's native audio stack
+    //      (managed runtimes, IPC channels, WAV capture fixtures, etc.).
+    //   2. Compile-time USE_ALSA — the traditional Linux host path.
+    //   3. Neither — PCI device enumerates but the stream worker drops PCM.
+    if (write_fn != NULL) {
+        sound_hda_backend_bridge_t *bridge = safe_new_obj(sound_hda_backend_bridge_t);
+        bridge->user_fn = write_fn;
+        bridge->user_data = user_data;
+        sound_hda->subsystem.sound_data = bridge;
+        sound_hda->subsystem.write = sound_hda_backend_bridge_write;
+    } else {
 #ifdef USE_ALSA
-    if (!alsa_sound_init(&sound_hda->subsystem))
-        return NULL;
+        if (!alsa_sound_init(&sound_hda->subsystem))
+            return NULL;
 #endif
+    }
 
     return pci_dev;
+}
+
+PUBLIC pci_dev_t *sound_hda_init_auto_ex(rvvm_machine_t *machine,
+                                         sound_hda_backend_write_fn write_fn,
+                                         void *user_data)
+{
+    return sound_hda_init_ex(rvvm_get_pci_bus(machine), write_fn, user_data);
+}
+
+PUBLIC pci_dev_t *sound_hda_init(pci_bus_t *pci_bus)
+{
+    return sound_hda_init_ex(pci_bus, NULL, NULL);
 }
 
 PUBLIC pci_dev_t *sound_hda_init_auto(rvvm_machine_t *machine)

--- a/src/devices/sound-hda.c
+++ b/src/devices/sound-hda.c
@@ -396,13 +396,50 @@ static bool sound_hda_mmio_read(rvvm_mmio_dev_t* dev, void* data, size_t offset,
         case SOUND_HDA_INTR_CTRL:
             write_uint32_le(data, hda->intr_ctrl);
             break;
-        case SOUND_HDA_INTSTS:
-            // As per specification and to simplify this code,
-            // we assume that interrupt always occured when
-            // guest reads this. Value represent interrupt
-            // on the outptut stream.
-            write_uint32_le(data, 1 << 29);
+        case SOUND_HDA_INTSTS: {
+            // INTSTS (HDA spec 3.3.13): bits 0..29 are per-stream SIS
+            // flags (SDnSTS has any latched IRQ), bit 30 CIS (CORB/RIRB),
+            // bit 31 GIS (overall OR).
+            //
+            // Stream indices follow the descriptor order ISS, OSS, BSS:
+            // we advertise 1 input + 1 output, so ISD0 is stream 0
+            // (mask 1<<0) and OSD0 is stream 1 (mask 1<<1).
+            //
+            // Prior code returned `1 << 29`, claiming "stream 29 has an
+            // IRQ". Linux's azx_interrupt does
+            //   if (status & azx_dev->sd_int_sta_mask) { ... }
+            // over its stream_list (indices 0 and 1 for us). Bit 29
+            // never matches, the output stream's IRQ is silently
+            // dropped before snd_pcm_period_elapsed runs — same
+            // "writers never wake" failure mode as a missing BCIS.
+            uint32_t sts = 0;
+            if (hda->stream_output.status & 0x1C) {
+                sts |= 1u << 1;   // OSD0 = stream index 1
+            }
+            if (sts) sts |= (1u << 31);  // GIS mirrors any pending SIS
+            write_uint32_le(data, sts);
             break;
+        }
+        case SOUND_HDA_WALL_CLOCK: {
+            // HDA spec 3.3.18: 32-bit counter clocked at 24 MHz. Used by
+            // the Linux HDA driver (intel.c:azx_position_ok) as a sanity
+            // gate: if (now - start_wallclk) < (period_wallclk * 2/3),
+            // the IRQ is declared bogus and dropped before
+            // snd_pcm_period_elapsed runs. Returning 0 meant every IRQ
+            // was rejected, hw_ptr never advanced from the driver's POV,
+            // writers blocked in wait_for_avail until a signal arrived
+            // (mpg123: "wrote only N of M"). With a real monotonic
+            // 24 MHz counter the driver compares correctly, the gate
+            // passes once per period, and period_elapsed wakes writers.
+            //
+            // aplay @ 22 kHz mono never saw this because its byte rate
+            // (44 KB/s) is well below our BDL drain rate (96 KB/s) —
+            // the runtime buffer never filled, so wait_for_avail was
+            // never entered and WALLCLK was irrelevant.
+            uint32_t wallclk = (uint32_t)rvtimer_clocksource(24000000ULL);
+            write_uint32_le(data, wallclk);
+            break;
+        }
         case SOUND_HDA_CORB_WP:
             write_uint16_le(data, hda->corb_wp);
             break;
@@ -820,7 +857,13 @@ static void sound_hda_stream_drain(sound_hda_dev_t *hda)
             // math below stays 1:1 with the bytes they see.
             if (hda->subsystem.write != NULL) {
                 void *pcm = pci_get_dma_ptr(hda->pci_func, addr, len);
-                if (channels == 1 || pcm == NULL) {
+                if (pcm == NULL) {
+                    // Bad guest BDL entry (zero addr, unmapped region, or
+                    // zero len). Don't feed NULL to the backend — ALSA's
+                    // snd_pcm_writei(NULL, n) is UB and ringbuf writes
+                    // memcpy from NULL. Pacing still advances below so
+                    // LPIB keeps moving and the guest can recover.
+                } else if (channels == 1) {
                     hda->subsystem.write(&hda->subsystem, pcm, len);
                 } else if (bits_per_sample == 16) {
                     // Common case: 16-bit multi-channel → 16-bit mono.
@@ -881,8 +924,21 @@ static void sound_hda_stream_drain(sound_hda_dev_t *hda)
             // When LPIB goes over BDL length, we are done.
             if (stream->bdl_len > 0 && stream->lpib > stream->bdl_len)
                 atomic_store_uint32_relax(&stream->running, 0);
-            if (ioc)
+            if (ioc) {
+                // Latch BCIS (SDnSTS bit 2) before raising the IRQ. Linux's
+                // HDA ISR (snd_hdac_bus_handle_stream_irq) reads SD_STS,
+                // and only calls snd_pcm_period_elapsed when SD_INT_COMPLETE
+                // (== BCIS) is set. Without this bit, the IRQ is ack'd and
+                // discarded — hw_ptr stops advancing from the driver's POV,
+                // writers blocked in wait_for_avail never wake, and the
+                // stream decays into a stall that userspace sees as short
+                // or zero writes from snd_pcm_writei.
+                //
+                // HDA spec 3.3.38: BCIS is RW1C. Guest clears it via the
+                // existing OSD0STS write handler at sound_hda_mmio_write().
+                hda->stream_output.status |= 0x04;
                 pci_send_irq(hda->pci_func, 0);
+            }
         }
     }
 }

--- a/src/devices/sound-hda.c
+++ b/src/devices/sound-hda.c
@@ -304,7 +304,8 @@ typedef struct {
     uint8_t     ioce;
     uint8_t     stream;
     uint8_t     channel;
-    uint32_t    running;
+    uint32_t    running;       // Guest intent: 1 = stream should be running
+    uint32_t    worker_alive;  // Worker lifetime: 1 = worker thread exists
     uint8_t     fmt;
     uint8_t     status;
     uint8_t     left_gain;
@@ -338,22 +339,28 @@ typedef struct {
 
 static void sound_hda_remove(rvvm_mmio_dev_t* dev)
 {
-    // Halt the stream worker(s) before the PCI function is torn down.
+    // Halt the stream worker before the PCI function is torn down.
     // Without this, a worker still walking the BDL will call
     // pci_send_irq() / pci_get_dma_ptr() on a freed pci_func and crash.
     //
-    // Setting running=0 asks the worker to exit at its next BDL-entry
-    // boundary (typically within a few ms for a 128-frame period).
-    // Ideally we'd also thread_join on the worker, but RVVM's
-    // thread_create_task fire-and-forgets, so we settle for a short
-    // spin-wait: give the worker time to observe the flag.
+    // running=0 asks the worker to exit at the top of its next drain
+    // iteration. worker_alive is cleared by the worker when it actually
+    // returns — polling it is a reliable join, since thread_create_task
+    // is fire-and-forget and RVVM has no matching thread handle here.
     sound_hda_dev_t *hda = dev->data;
     if (hda != NULL) {
-        atomic_store_uint32_relax(&hda->stream_output.running, 0);
-        // The HDA stream period is 128 frames at 192 kHz = ~667 µs wall.
-        // 20 ms of sleep is 30x that — comfortably long enough for the
-        // worker to finish its current iteration.
-        sleep_ms(20);
+        sound_hda_stream_t *stream = &hda->stream_output;
+        atomic_store_uint32_relax(&stream->running, 0);
+        // The worst-case drain-exit latency is one pacing-sleep period:
+        // at 48 kHz x 2 bytes, a 4 KiB BDL entry paces ~43 ms. Cap the
+        // wait at ~1 s as a liveness guard against a wedged backend
+        // (subsystem.write blocking inside the user callback). If we
+        // hit the cap, the device is being torn down anyway and the
+        // worst outcome is a brief thread leak — not a use-after-free.
+        for (int i = 0; i < 200; i++) {
+            if (!atomic_load_uint32_relax(&stream->worker_alive)) break;
+            sleep_ms(5);
+        }
     }
 }
 
@@ -728,9 +735,12 @@ static void sound_hda_codec_cmd(sound_hda_dev_t *hda, uint32_t cmd)
     sound_hda_write_rirb(hda, cad, response);
 }
 
-static void *sound_hda_stream_worker(void *arg)
+// Drain the stream once: read current fmt/BDL, pace PCM to the backend
+// until the guest clears running (or an unrecoverable condition bails).
+// Separate from the worker-lifetime loop below so early-bail paths can
+// just return without touching worker_alive.
+static void sound_hda_stream_drain(sound_hda_dev_t *hda)
 {
-    sound_hda_dev_t *hda = arg;
     sound_hda_stream_t *stream = &hda->stream_output;
 
     // Pace the worker to the stream's configured bytes-per-second.
@@ -770,7 +780,7 @@ static void *sound_hda_stream_worker(void *arg)
         // Guest wrote run=1 before configuring the format. Bail out
         // like the NULL-dma case — driver will retry properly.
         atomic_store_uint32_relax(&stream->running, 0);
-        return NULL;
+        return;
     }
     uint64_t       paced_start_ns  = 0;
     uint64_t       paced_bytes_out = 0;
@@ -784,7 +794,7 @@ static void *sound_hda_stream_worker(void *arg)
     // proper BDL when userspace opens another PCM handle.
     if (dma == NULL) {
         atomic_store_uint32_relax(&stream->running, 0);
-        return NULL;
+        return;
     }
 
     while (atomic_load_uint32_relax(&stream->running)) {
@@ -875,8 +885,31 @@ static void *sound_hda_stream_worker(void *arg)
                 pci_send_irq(hda->pci_func, 0);
         }
     }
+}
 
-    return NULL;
+static void *sound_hda_stream_worker(void *arg)
+{
+    sound_hda_dev_t *hda = arg;
+    sound_hda_stream_t *stream = &hda->stream_output;
+
+    // Worker lifetime is published via worker_alive. Loop handles a narrow
+    // missed-wakeup window: guest writes run=1 after we read running=0 but
+    // before we clear worker_alive — its spawn CAS sees worker_alive=1
+    // and skips, leaving no worker for a running stream. We catch that by
+    // re-reading running after the clear, and re-claim the slot to drain
+    // again. If a concurrent spawn already won the CAS, they own the next
+    // drain — we exit. Either way, exactly one worker runs at a time.
+    for (;;) {
+        sound_hda_stream_drain(hda);
+
+        atomic_store_uint32_relax(&stream->worker_alive, 0);
+
+        if (!atomic_load_uint32_relax(&stream->running))
+            return NULL;
+        if (!atomic_cas_uint32(&stream->worker_alive, 0, 1))
+            return NULL;
+        // Re-claimed the slot; drain again with freshly-read stream state.
+    }
 }
 
 static void sound_hda_output_stream_ctl(sound_hda_dev_t *hda, uint32_t cmd)
@@ -888,14 +921,20 @@ static void sound_hda_output_stream_ctl(sound_hda_dev_t *hda, uint32_t cmd)
     stream->ioce = ioce;
 
     if (run) {
-        // Only spawn a worker if one isn't already running. Without this
-        // guard, a guest that writes run=1 twice in quick succession (or
-        // a backend slow enough that one aplay ends before the worker
-        // exits and the next aplay starts) can leave two workers walking
-        // the same stream struct. They'd race on stream->lpib / running,
-        // and if one worker's cached dma pointer got stale from a guest
-        // BDL update in between, dereferencing it crashes.
-        if (atomic_cas_uint32(&stream->running, 0, 1)) {
+        // Publish guest intent first, THEN gate the spawn on worker_alive.
+        // Ordering matters: a worker exiting its while-loop right now will
+        // clear worker_alive after its last running-check. If we set
+        // running=1 before it clears, our subsequent CAS will either win
+        // the slot (worker already gone) or lose it (worker still alive),
+        // and the worker's post-clear re-check of running catches the case
+        // where we lost the CAS but running=1 still needs a worker.
+        atomic_store_uint32_relax(&stream->running, 1);
+        // Gate on worker_alive (not running): running is guest intent and
+        // can flip repeatedly while a single worker drains a stream.
+        // worker_alive is owned by the worker — set here on spawn, cleared
+        // only by the worker at function return — so it stays 1 across the
+        // entire window where a second thread would trample stream state.
+        if (atomic_cas_uint32(&stream->worker_alive, 0, 1)) {
             thread_create_task(sound_hda_stream_worker, hda);
         }
     } else {

--- a/src/devices/sound-hda.c
+++ b/src/devices/sound-hda.c
@@ -11,6 +11,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #include "atomics.h"
 #include "compiler.h"
 #include "mem_ops.h"
+#include "rvtimer.h"
 #include "threading.h"
 #include "spinlock.h"
 #include "utils.h"
@@ -337,7 +338,25 @@ typedef struct {
 
 static void sound_hda_remove(rvvm_mmio_dev_t* dev)
 {
-    UNUSED(dev);
+    // Halt the stream worker(s) before the PCI function is torn down.
+    // Without this, a worker still walking the BDL will call
+    // pci_send_irq() / pci_get_dma_ptr() on a freed pci_func and crash.
+    //
+    // Setting running=0 asks the worker to exit at its next BDL-entry
+    // boundary (typically within a few ms for a 128-frame period).
+    // Ideally we'd also thread_join on the worker, but RVVM's
+    // thread_create_task fire-and-forgets, so we settle for a short
+    // spin-wait: give the worker time to observe the flag.
+    sound_hda_dev_t *hda = dev->data;
+    if (hda != NULL) {
+        atomic_store_uint32_relax(&hda->stream_output.running, 0);
+        // A BDL entry at 48 kHz × 2 bytes is typically 256-4096 bytes =
+        // ~3-43 ms of wall-clock per iteration under the new pacing loop.
+        // 20 ms is enough for the worker to notice the flag before the
+        // next iteration in the common (small-period) case; the worst-
+        // case long-period still exits at the top of the next loop.
+        sleep_ms(20);
+    }
 }
 
 static rvvm_mmio_type_t sound_hda_type = {
@@ -471,7 +490,20 @@ static uint32_t sound_hda_codec_fg_output_cmd(uint32_t payload)
             return CODEC_PARAM_FUNC_GROUP_TYPE_AUDIO;
 
         case CODEC_PARAM_SUPP_PCM_SIZE_RATES:
-            return (0x1F << 16) | 0x7FF; // B8 - B32, 8.0 - 192.0kHz
+            // Advertise ONLY 48 kHz, 16-bit. If we advertised the full
+            // 8-192 kHz / 8-32 bit range, the Linux driver would let the
+            // application pick its file's native rate, but the stream
+            // worker has no per-stream rate awareness — it paces to a
+            // fixed bytes/sec. So playing a 48 kHz WAV against a codec
+            // that accepts 192 kHz caused 4× slow playback + aliasing.
+            //
+            // Fixing the codec to one format makes ALSA + the HDA driver
+            // handle any rate mismatch in software (linear-interp upsample
+            // or straight passthrough), with the emulator's rate
+            // always matching the pacing math. 48 kHz mono 16-bit is
+            // what every common audio file decodes to after ffmpeg/afconvert,
+            // so the hot path is pure passthrough.
+            return (1 << 17) | (1 << 6); // 16-bit, 48 kHz
 
         case CODEC_PARAM_SUPP_STREAM_FMTS:
             return CODEC_PARAM_SUPP_STREAM_FMTS_PCM;
@@ -498,14 +530,19 @@ static uint32_t sound_hda_codec_output_cmd(uint32_t payload)
             return 0x00010001; // 1 Subnode, StartNid = 1
 
         case CODEC_PARAM_AUDIO_WIDGET_CAPS:
+            // No STEREO bit: tell the guest driver this widget is mono
+            // only. Prevents Linux from configuring a stereo stream
+            // (which it will by default on stereo-capable widgets, even
+            // for mono input, and then silently downmixes the input
+            // duplicating mono → L+R — so the emulator byte rate
+            // doubles and pacing diverges).
             return CODEC_PARAM_AUDIO_WIDGET_CAPS_OUTPUT
                  | CODEC_PARAM_AUDIO_WIDGET_CAPS_FORMAT_OVR
                  | CODEC_PARAM_AUDIO_WIDGET_CAPS_AMP_OVR
-                 | CODEC_PARAM_AUDIO_WIDGET_CAPS_AMP_OUT
-                 | CODEC_PARAM_AUDIO_WIDGET_CAPS_STEREO;
+                 | CODEC_PARAM_AUDIO_WIDGET_CAPS_AMP_OUT;
 
         case CODEC_PARAM_SUPP_PCM_SIZE_RATES:
-            return (0x1F << 16) | 0x7FF; // B8 - B32, 8.0 - 192.0kHz
+            return (1 << 17) | (1 << 6); // 16-bit, 48 kHz (see root-node comment)
 
         case CODEC_PARAM_SUPP_STREAM_FMTS:
             return CODEC_PARAM_SUPP_STREAM_FMTS_PCM;
@@ -526,9 +563,10 @@ static uint32_t sound_hda_codec_pin_output_cmd(uint32_t payload)
 {
     switch (payload) {
         case CODEC_PARAM_AUDIO_WIDGET_CAPS:
+            // Mono pin to match the output widget; see the output-widget
+            // caps comment above.
             return CODEC_PARAM_AUDIO_WIDGET_CAPS_PIN
-                 | CODEC_PARAM_AUDIO_WIDGET_CAPS_CONN_LIST
-                 | CODEC_PARAM_AUDIO_WIDGET_CAPS_STEREO;
+                 | CODEC_PARAM_AUDIO_WIDGET_CAPS_CONN_LIST;
 
         case CODEC_PARAM_PIN_CAPS:
             return CODEC_PARAM_PIN_CAPS_OUTPUT
@@ -697,8 +735,60 @@ static void *sound_hda_stream_worker(void *arg)
     sound_hda_dev_t *hda = arg;
     sound_hda_stream_t *stream = &hda->stream_output;
 
+    // Pace the worker to the stream's configured bytes-per-second.
+    // Without pacing, non-blocking backends (ring buffers, null sinks)
+    // let this loop blast through the BDL as fast as the CPU allows:
+    // LPIB advances instantly, the guest HDA driver sees its DMA
+    // "consume" data faster than it can refill, and aplay trips ALSA's
+    // position-consistency assertion ("pcm_plugin.c Assertion
+    // status->appl_ptr == *pcm->appl.ptr failed"). Blocking backends
+    // (ALSA's snd_pcm_writei) dodge this accidentally because writei
+    // blocks when the host buffer fills.
+    //
+    // The rate is derived from stream->fmt per HDA spec 7.3.3.10:
+    //   bit  14      : base rate        (0=48000, 1=44100)
+    //   bits 13:11   : rate multiplier  (N+1: 1×, 2×, 3×, 4×)
+    //   bits 10:8    : rate divisor     (N+1: /1 .. /8)
+    //   bits 6:4     : bits/sample      (0=8, 1=16, 2=20, 3=24, 4=32)
+    //   bits 3:0     : channels minus 1 (0=1ch, 1=2ch, …)
+    //
+    // A previous iteration hardcoded 192 kHz mono then later 48 kHz
+    // mono — both broke when the guest driver chose a different stream
+    // format (Linux HDA likes to configure stereo streams even for mono
+    // content, doubling the true byte rate). Deriving from fmt is the
+    // only way to be robust across guest driver choices.
+    uint16_t fmt             = stream->fmt;
+    uint32_t channels        = (fmt & 0xF) + 1;
+    uint32_t bits_code       = (fmt >> 4) & 7;
+    uint32_t bits_per_sample = bits_code == 0 ? 8  : bits_code == 1 ? 16 :
+                               bits_code == 2 ? 20 : bits_code == 3 ? 24 : 32;
+    uint32_t bytes_per_frame = channels * ((bits_per_sample + 7) / 8);
+    uint32_t div             = ((fmt >> 8)  & 7) + 1;
+    uint32_t mult            = ((fmt >> 11) & 7) + 1;
+    uint32_t base_hz         = (fmt & (1 << 14)) ? 44100 : 48000;
+    uint64_t sample_rate_hz  = (uint64_t)base_hz * mult / div;
+    uint64_t SAMPLE_RATE_BYTES_PER_SEC = sample_rate_hz * bytes_per_frame;
+    if (SAMPLE_RATE_BYTES_PER_SEC == 0) {
+        // Guest wrote run=1 before configuring the format. Bail out
+        // like the NULL-dma case — driver will retry properly.
+        atomic_store_uint32_relax(&stream->running, 0);
+        return NULL;
+    }
+    uint64_t       paced_start_ns  = 0;
+    uint64_t       paced_bytes_out = 0;
+
     uint32_t total = stream->bdl_lvi + 1;
     uint64_t *dma = pci_get_dma_ptr(hda->pci_func, stream->bdl_lo, stream->bdl_len);
+
+    // If the guest set up the stream control register without a valid BDL
+    // (bdl_lo == 0 or invalid), pci_get_dma_ptr returns NULL. Bail out
+    // cleanly — the guest's ALSA driver will eventually retry with a
+    // proper BDL when userspace opens another PCM handle.
+    if (dma == NULL) {
+        atomic_store_uint32_relax(&stream->running, 0);
+        return NULL;
+    }
+
     while (atomic_load_uint32_relax(&stream->running)) {
         for (uint32_t i = 0; i < total; ++i) {
             uint64_t *bdle = &dma[i * 2];
@@ -706,14 +796,72 @@ static void *sound_hda_stream_worker(void *arg)
             uint32_t len  = bdle[1] & 0xFFFFFFFF;
             uint8_t  ioc  = bdle[1] >> 32 & 1;
 
+            // Backend contract: always receives MONO 16-bit LE at the
+            // stream's configured rate. If the guest driver configured a
+            // multi-channel stream (Linux's HDA code likes stereo even
+            // when the codec widget advertises mono capability), we
+            // downmix here by averaging channels — keeps the backend's
+            // job simple and the pacing math below stays 1:1 with the
+            // bytes it sees.
 #ifdef USE_ALSA
-            void *pcm = pci_get_dma_ptr(hda->pci_func, addr, len);
-            hda->subsystem.write(&hda->subsystem, pcm, len);
+            {
+                void *pcm = pci_get_dma_ptr(hda->pci_func, addr, len);
+                if (channels == 1 || pcm == NULL) {
+                    hda->subsystem.write(&hda->subsystem, pcm, len);
+                } else if (bits_per_sample == 16) {
+                    // Common case: 16-bit multi-channel → 16-bit mono.
+                    // Stack-allocate — BDL entries are small (256-4096 B).
+                    size_t frame_bytes_in = (size_t)bytes_per_frame;
+                    size_t frames         = len / frame_bytes_in;
+                    int16_t *src = (int16_t*)pcm;
+                    int16_t  mono_buf[4096];
+                    size_t bytes_emitted = 0;
+                    while (bytes_emitted < frames * 2) {
+                        size_t chunk_frames = frames - (bytes_emitted / 2);
+                        if (chunk_frames > 4096) chunk_frames = 4096;
+                        for (size_t f = 0; f < chunk_frames; f++) {
+                            int32_t sum = 0;
+                            size_t base = (bytes_emitted / 2 + f) * channels;
+                            for (uint32_t c = 0; c < channels; c++) {
+                                sum += src[base + c];
+                            }
+                            mono_buf[f] = (int16_t)(sum / (int32_t)channels);
+                        }
+                        hda->subsystem.write(&hda->subsystem, mono_buf, chunk_frames * 2);
+                        bytes_emitted += chunk_frames * 2;
+                    }
+                } else {
+                    // Rare: non-16-bit multi-channel. Pass raw.
+                    hda->subsystem.write(&hda->subsystem, pcm, len);
+                }
+            }
 #else
-            // TODO: Stub backend or don't compile this file if no
-            //       sound compilation option?
+            // No compile-time backend: LPIB still advances (paced below)
+            // so the guest's HDA driver doesn't stall, but PCM is dropped.
             UNUSED(addr);
 #endif
+
+            // Wall-clock pacing. Compute the ideal elapsed time for the
+            // bytes we've emitted so far and sleep the difference.
+            paced_bytes_out += len;
+            uint64_t now_ns = rvtimer_clocksource(1000000000ULL);
+            if (paced_start_ns == 0) {
+                paced_start_ns = now_ns;
+            } else {
+                uint64_t expected_ns = paced_bytes_out * 1000000000ULL
+                                     / SAMPLE_RATE_BYTES_PER_SEC;
+                uint64_t elapsed_ns  = now_ns - paced_start_ns;
+                if (expected_ns > elapsed_ns) {
+                    sleep_ns(expected_ns - elapsed_ns);
+                } else if (elapsed_ns > expected_ns + 100000000ULL) {
+                    // Fell more than 100 ms behind — rebase so we don't
+                    // try to "catch up" by blasting. Happens on machine
+                    // resume from pause, or very long Java-side GCs.
+                    paced_start_ns  = now_ns;
+                    paced_bytes_out = 0;
+                }
+            }
+
             stream->lpib += len;
             // If stream longer than BDL length, reset LPIB.
             if (stream->lpib >= stream->bdl_len)
@@ -738,8 +886,16 @@ static void sound_hda_output_stream_ctl(sound_hda_dev_t *hda, uint32_t cmd)
     stream->ioce = ioce;
 
     if (run) {
-        atomic_store_uint32_relax(&stream->running, 1);
-        thread_create_task(sound_hda_stream_worker, hda);
+        // Only spawn a worker if one isn't already running. Without this
+        // guard, a guest that writes run=1 twice in quick succession (or
+        // a backend slow enough that one aplay ends before the worker
+        // exits and the next aplay starts) can leave two workers walking
+        // the same stream struct. They'd race on stream->lpib / running,
+        // and if one worker's cached dma pointer got stale from a guest
+        // BDL update in between, dereferencing it crashes.
+        if (atomic_cas_uint32(&stream->running, 0, 1)) {
+            thread_create_task(sound_hda_stream_worker, hda);
+        }
     } else {
         atomic_store_uint32_relax(&stream->running, 0);
     }

--- a/src/devices/sound-hda.h
+++ b/src/devices/sound-hda.h
@@ -20,10 +20,41 @@ struct sound_subsystem_t {
     void (*write)(sound_subsystem_t *subsystem, void *data, size_t size);
 };
 
+/*
+ * Public callback type for library consumers who want to install their own
+ * host-side audio sink without going through a compile-time USE_* backend.
+ *
+ * The HDA stream worker invokes this callback on its own thread with a chunk
+ * of 16-bit signed little-endian PCM data — mono, 48 kHz, matching the
+ * format the codec advertises. `user_data` is whatever pointer was passed
+ * to sound_hda_init_ex / sound_hda_init_auto_ex.
+ *
+ * Useful for embedders routing audio into a non-native audio stack (a
+ * managed runtime, an IPC channel, a WAV capture test harness, etc.)
+ * without relying on a backend compiled into librvvm.
+ */
+typedef void (*sound_hda_backend_write_fn)(void *user_data, void *pcm_data, size_t size);
+
 // Internal use
 bool alsa_sound_init(sound_subsystem_t *sound);
 
 PUBLIC pci_dev_t* sound_hda_init(pci_bus_t* pci_bus);
 PUBLIC pci_dev_t* sound_hda_init_auto(rvvm_machine_t* machine);
+
+/*
+ * Extended init variants that let the caller plug in a custom host-side
+ * audio sink. Pass NULL for `write_fn` to fall back to the compile-time
+ * default (USE_ALSA if enabled, silent otherwise — same behaviour as
+ * sound_hda_init / sound_hda_init_auto).
+ *
+ * When a non-NULL `write_fn` is supplied, the HDA device skips any
+ * compiled-in backend and routes every PCM chunk through `write_fn`.
+ */
+PUBLIC pci_dev_t* sound_hda_init_ex(pci_bus_t* pci_bus,
+                                    sound_hda_backend_write_fn write_fn,
+                                    void* user_data);
+PUBLIC pci_dev_t* sound_hda_init_auto_ex(rvvm_machine_t* machine,
+                                         sound_hda_backend_write_fn write_fn,
+                                         void* user_data);
 
 #endif


### PR DESCRIPTION
Six commits restoring the HDA output stream path end-to-end. Each is independently reviewable; they cluster into two themes — **stream worker correctness** and **host ALSA backend robustness** — with one API addition.

## Stream worker

1. **`sound-hda: Fix stream worker crashes, pacing, and codec format mismatch`** (`45d331c`)
   - `sound_hda_remove` halts the worker before `pci_func` teardown (prior: SIGSEGV on machine free).
   - Wall-clock pacing, derived per-stream from `stream->fmt` per HDA 7.3.3.10 (prior: `aplay` tripped `pcm_plugin.c:547` on non-blocking backends).
   - NULL-`dma` guard + `atomic_cas` on worker spawn.
   - Codec locked to 48 kHz mono 16-bit + defensive mono downmix in the worker.

2. **`sound-hda: Split worker lifetime from guest run-intent`** (`fe6683e`)
   Response to @epoll-reactor-2's review: the original CAS-on-`running` could race when guest stop+start interleaved with a worker mid-pacing-sleep. Split `worker_alive` (owned by worker) from `running` (guest intent). Drain entry is gated by CAS on `worker_alive`; worker re-claims the slot after its clear to cover the narrow missed-wakeup window. Exactly one worker ever executes `sound_hda_stream_drain` at a time.

3. **`sound-hda: Fix IRQ dispatch chain so period-elapsed wakes writers`** (`3c6cf25`)
   Three interdependent bugs silently dropped every output-stream IRQ before `snd_pcm_period_elapsed` ran. Streaming playback (mpg123) wrote a frame or two then reported `wrote only N of M (No error information?)`; file-backed `aplay` at low rates slipped through because the runtime buffer never filled. Fixes:
   - `INTSTS` was returning `1<<29`; Linux's `azx_interrupt` masks by stream index, expects `1<<1` for the single output stream.
   - BCIS (`SDnSTS` bit 2) wasn't being latched on IOC, so `snd_hdac_bus_handle_stream_irq` skipped the ack callback.
   - `WALLCLK` was stuck at 0; `intel.c:azx_position_ok` compares it against `period_wallclk * 2/3` and rejects every IRQ as bogus. Now backed by a 24 MHz counter off `rvtimer_clocksource`.

## Host ALSA backend

4. **`sound-alsa: Match HDA codec format and widen host PCM buffer`** (`f1d5a61`)
   - Open host PCM at 48 kHz to match the codec lock in commit 1 (prior: 192 kHz host vs 48 kHz codec → 4× fast playback).
   - 960-frame period / 3840-frame buffer (~20 ms / 80 ms at 48 kHz); 128 frames was too tight and caused PipeWire xruns under normal host scheduler jitter.

5. **`sound-alsa: Retry on xrun and drain short writes instead of dropping`** (`0e2b4ed`)
   `alsa_sound_write` called `snd_pcm_writei` exactly once; `-EPIPE` / `-ESTRPIPE` / `-EINTR` and positive short returns all silently dropped frames → audible clicks. Now loops until every frame is delivered with xrun/EINTR/EAGAIN retry handling, bounded retry count against a disconnected device.

## API

6. **`sound-hda: Add pluggable host-backend API (sound_hda_init_ex)`** (`bd0eb85`)
   Public `sound_hda_init_ex` / `_auto_ex` accepting a `void (*write_fn)(void*, void*, size_t)` + opaque user data. NULL preserves `USE_ALSA` behaviour byte-for-byte; non-NULL routes PCM through the caller. Existing `sound_hda_init` / `_auto` remain as one-line wrappers. Optional — happy to drop if your upcoming bindings API will supersede.

## Test plan

- [x] Linux x86_64 native build clean on GCC + Clang
- [x] All CI platforms green (Linux/Windows/macOS/FreeBSD/OpenBSD/Cosmo × arch matrix)
- [x] `aplay` no longer hits the `pcm_plugin.c:547` assertion
- [x] `apk add wget mpg123; mpg123 https://ice1.somafm.com/groovesalad-128` — sustained streaming playback works end-to-end in rvvm on a Linux host (also the main-branch test path for the sound stack)
- [x] Machine free during active stream no longer SIGSEGVs
- [x] Rapid guest stop+start cycles no longer produce overlapping drains
- [x] `USE_ALSA=0` builds unchanged; `USE_ALSA=1` with NULL `write_fn` byte-identical to pre-patch
