### PR TITLE
sound-hda: Fix UAF in remove() worker halt (#208)

### DIFF
--- a/src/devices/alsa.c
+++ b/src/devices/alsa.c
@@ -9,6 +9,7 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #ifdef USE_ALSA
 
+#include "atomics.h"
 #include "compiler.h"
 #include "dlib.h"
 #include "sound-hda.h"
@@ -34,6 +35,7 @@ ASOUND_DLIB_SYM(snd_pcm_hw_params)
 ASOUND_DLIB_SYM(snd_pcm_writei)
 ASOUND_DLIB_SYM(snd_pcm_prepare)
 ASOUND_DLIB_SYM(snd_pcm_drain)
+ASOUND_DLIB_SYM(snd_pcm_drop)
 ASOUND_DLIB_SYM(snd_pcm_close)
 ASOUND_DLIB_SYM(snd_pcm_hw_params_free)
 
@@ -50,11 +52,19 @@ ASOUND_DLIB_SYM(snd_pcm_hw_params_free)
 #define snd_pcm_writei snd_pcm_writei_dlib
 #define snd_pcm_prepare snd_pcm_prepare_dlib
 #define snd_pcm_drain snd_pcm_drain_dlib
+#define snd_pcm_drop snd_pcm_drop_dlib
 #define snd_pcm_close snd_pcm_close_dlib
 #define snd_pcm_hw_params_free snd_pcm_hw_params_free_dlib
 
 typedef struct {
     snd_pcm_t *pcm_handle;
+    // Set by alsa_sound_abort() when the HDA device is being removed.
+    // alsa_sound_write() checks this on every iteration so a blocked
+    // writei that abort has unblocked (via snd_pcm_drop) does not loop
+    // back through snd_pcm_prepare + retry and stay stuck. Access is
+    // cross-thread: abort runs on the teardown thread, write on the
+    // stream worker.
+    uint32_t aborted;
 } alsa_subsystem_t;
 
 static void alsa_sound_write(sound_subsystem_t *subsystem, void *data, size_t size)
@@ -76,6 +86,12 @@ static void alsa_sound_write(sound_subsystem_t *subsystem, void *data, size_t si
     int xrun_retries = 4;
 
     while (remaining > 0) {
+        // Abort requested by teardown; drop the rest of the chunk so the
+        // stream worker unblocks promptly. Checked before writei so a
+        // post-drop retry (snd_pcm_drop forces the next writei to return
+        // -EPIPE) does not slip back into prepare+retry.
+        if (atomic_load_uint32_relax(&alsa->aborted)) return;
+
         snd_pcm_sframes_t n = snd_pcm_writei(alsa->pcm_handle, buf, remaining);
         if (n < 0) {
             if (n == -EAGAIN || n == -EINTR) {
@@ -96,6 +112,16 @@ static void alsa_sound_write(sound_subsystem_t *subsystem, void *data, size_t si
         buf       += n;     // int16_t* step = one sample per element
         remaining -= n;
     }
+}
+
+static void alsa_sound_abort(sound_subsystem_t *subsystem)
+{
+    alsa_subsystem_t *alsa = subsystem->sound_data;
+    // Publish the flag before unblocking writei. snd_pcm_drop causes any
+    // in-flight writei to return -EPIPE; the write loop then sees the
+    // flag and bails instead of looping through snd_pcm_prepare.
+    atomic_store_uint32_relax(&alsa->aborted, 1);
+    snd_pcm_drop(alsa->pcm_handle);
 }
 
 static bool alsa_load_symbols(void)
@@ -127,6 +153,7 @@ do { \
     ASOUND_DLIB_RESOLVE(libasound, snd_pcm_writei);
     ASOUND_DLIB_RESOLVE(libasound, snd_pcm_prepare);
     ASOUND_DLIB_RESOLVE(libasound, snd_pcm_drain);
+    ASOUND_DLIB_RESOLVE(libasound, snd_pcm_drop);
     ASOUND_DLIB_RESOLVE(libasound, snd_pcm_close);
     ASOUND_DLIB_RESOLVE(libasound, snd_pcm_hw_params_free);
 
@@ -187,6 +214,7 @@ bool alsa_sound_init(sound_subsystem_t *sound)
 
     sound->sound_data = subsystem;
     sound->write = alsa_sound_write;
+    sound->abort = alsa_sound_abort;
 
     return true;
 }

--- a/src/devices/sound-hda.c
+++ b/src/devices/sound-hda.c
@@ -343,23 +343,33 @@ static void sound_hda_remove(rvvm_mmio_dev_t* dev)
     // Without this, a worker still walking the BDL will call
     // pci_send_irq() / pci_get_dma_ptr() on a freed pci_func and crash.
     //
-    // running=0 asks the worker to exit at the top of its next drain
-    // iteration. worker_alive is cleared by the worker when it actually
-    // returns — polling it is a reliable join, since thread_create_task
-    // is fire-and-forget and RVVM has no matching thread handle here.
+    // running=0 asks the worker to exit. Paired with the running check
+    // inside the inner BDL loop in sound_hda_stream_drain, the worker
+    // bails within one backend write — it does not run the pacing
+    // sleep or IRQ dispatch on an entry observed after shutdown, so
+    // no pci_func access outlives this call.
+    //
+    // worker_alive is cleared by the worker when it actually returns —
+    // polling it is a reliable join, since thread_create_task is
+    // fire-and-forget and RVVM has no matching thread handle here.
+    //
+    // We wait unbounded: hanging on teardown is recoverable (the host
+    // notices and kills the process), but returning while the worker
+    // is still live and using hda->pci_func is a use-after-free the
+    // moment the caller frees the PCI state. Log a one-shot warning
+    // after 5 s as a diagnostic breadcrumb for a wedged backend.
     sound_hda_dev_t *hda = dev->data;
     if (hda != NULL) {
         sound_hda_stream_t *stream = &hda->stream_output;
         atomic_store_uint32_relax(&stream->running, 0);
-        // The worst-case drain-exit latency is one pacing-sleep period:
-        // at 48 kHz x 2 bytes, a 4 KiB BDL entry paces ~43 ms. Cap the
-        // wait at ~1 s as a liveness guard against a wedged backend
-        // (subsystem.write blocking inside the user callback). If we
-        // hit the cap, the device is being torn down anyway and the
-        // worst outcome is a brief thread leak — not a use-after-free.
-        for (int i = 0; i < 200; i++) {
-            if (!atomic_load_uint32_relax(&stream->worker_alive)) break;
+        uint32_t waited_ms = 0;
+        while (atomic_load_uint32_relax(&stream->worker_alive)) {
             sleep_ms(5);
+            waited_ms += 5;
+            if (waited_ms == 5000) {
+                DO_ONCE(rvvm_warn("sound_hda_remove: stream worker still alive"
+                                  " after 5 s; backend may be blocking"));
+            }
         }
     }
 }
@@ -895,6 +905,17 @@ static void sound_hda_stream_drain(sound_hda_dev_t *hda)
             } else {
                 UNUSED(addr);
             }
+
+            // Shutdown check between backend write and pacing / IRQ
+            // dispatch. The outer `while (running)` only gates the
+            // BDL pass; once started, a full pass is up to (lvi+1)
+            // entries × ~43 ms of pacing — several seconds the
+            // device might already be torn down behind us. Bailing
+            // here ensures no pci_send_irq / pci_get_dma_ptr call
+            // outlives sound_hda_remove(), which is how #208 got
+            // a freed pci_func under the IRQ dispatch.
+            if (!atomic_load_uint32_relax(&stream->running))
+                return;
 
             // Wall-clock pacing. Compute the ideal elapsed time for the
             // bytes we've emitted so far and sleep the difference.

--- a/src/devices/sound-hda.c
+++ b/src/devices/sound-hda.c
@@ -362,6 +362,16 @@ static void sound_hda_remove(rvvm_mmio_dev_t* dev)
     if (hda != NULL) {
         sound_hda_stream_t *stream = &hda->stream_output;
         atomic_store_uint32_relax(&stream->running, 0);
+        // Unblock a worker stuck inside subsystem.write before we start
+        // waiting. Without this, blocking backends (ALSA PCM mid-xrun,
+        // IPC sinks, any callback that doesn't poll running itself)
+        // stall teardown for as long as the host takes to drain — which
+        // for PipeWire under load can be seconds. Non-blocking backends
+        // leave abort NULL; the running check in sound_hda_stream_drain
+        // is enough for them.
+        if (hda->subsystem.abort != NULL) {
+            hda->subsystem.abort(&hda->subsystem);
+        }
         uint32_t waited_ms = 0;
         while (atomic_load_uint32_relax(&stream->worker_alive)) {
             sleep_ms(5);
@@ -1160,6 +1170,7 @@ static bool sound_hda_mmio_write(rvvm_mmio_dev_t* dev, void* data, size_t offset
  */
 typedef struct {
     sound_hda_backend_write_fn user_fn;
+    sound_hda_backend_abort_fn abort_fn;
     void                       *user_data;
 } sound_hda_backend_bridge_t;
 
@@ -1171,8 +1182,17 @@ static void sound_hda_backend_bridge_write(sound_subsystem_t *sub, void *data, s
     }
 }
 
+static void sound_hda_backend_bridge_abort(sound_subsystem_t *sub)
+{
+    sound_hda_backend_bridge_t *bridge = (sound_hda_backend_bridge_t *)sub->sound_data;
+    if (bridge != NULL && bridge->abort_fn != NULL) {
+        bridge->abort_fn(bridge->user_data);
+    }
+}
+
 PUBLIC pci_dev_t *sound_hda_init_ex(pci_bus_t *pci_bus,
                                     sound_hda_backend_write_fn write_fn,
+                                    sound_hda_backend_abort_fn abort_fn,
                                     void *user_data)
 {
     sound_hda_dev_t *sound_hda = safe_new_obj(sound_hda_dev_t);
@@ -1208,9 +1228,16 @@ PUBLIC pci_dev_t *sound_hda_init_ex(pci_bus_t *pci_bus,
     if (write_fn != NULL) {
         sound_hda_backend_bridge_t *bridge = safe_new_obj(sound_hda_backend_bridge_t);
         bridge->user_fn = write_fn;
+        bridge->abort_fn = abort_fn;
         bridge->user_data = user_data;
         sound_hda->subsystem.sound_data = bridge;
         sound_hda->subsystem.write = sound_hda_backend_bridge_write;
+        // Only publish the bridge's abort indirection when the caller
+        // actually supplied one — otherwise sound_hda_remove would
+        // invoke a no-op indirection every teardown.
+        if (abort_fn != NULL) {
+            sound_hda->subsystem.abort = sound_hda_backend_bridge_abort;
+        }
     } else {
 #ifdef USE_ALSA
         if (!alsa_sound_init(&sound_hda->subsystem))
@@ -1223,14 +1250,15 @@ PUBLIC pci_dev_t *sound_hda_init_ex(pci_bus_t *pci_bus,
 
 PUBLIC pci_dev_t *sound_hda_init_auto_ex(rvvm_machine_t *machine,
                                          sound_hda_backend_write_fn write_fn,
+                                         sound_hda_backend_abort_fn abort_fn,
                                          void *user_data)
 {
-    return sound_hda_init_ex(rvvm_get_pci_bus(machine), write_fn, user_data);
+    return sound_hda_init_ex(rvvm_get_pci_bus(machine), write_fn, abort_fn, user_data);
 }
 
 PUBLIC pci_dev_t *sound_hda_init(pci_bus_t *pci_bus)
 {
-    return sound_hda_init_ex(pci_bus, NULL, NULL);
+    return sound_hda_init_ex(pci_bus, NULL, NULL, NULL);
 }
 
 PUBLIC pci_dev_t *sound_hda_init_auto(rvvm_machine_t *machine)

--- a/src/devices/sound-hda.h
+++ b/src/devices/sound-hda.h
@@ -18,6 +18,15 @@ typedef struct sound_subsystem_t sound_subsystem_t;
 struct sound_subsystem_t {
     void *sound_data;
     void (*write)(sound_subsystem_t *subsystem, void *data, size_t size);
+    // Optional. Called from sound_hda_remove() before it waits for the
+    // stream worker to exit. Backends whose write() can block (host
+    // ALSA PCM, any IPC sink without an internal queue) must implement
+    // this so a blocked worker unblocks quickly — otherwise remove()
+    // waits on a wedged backend while the caller expects to free the
+    // machine. Non-blocking backends (ring buffers, capture fixtures)
+    // can leave this NULL. After abort() returns, subsequent write()
+    // calls are allowed to be no-ops; the worker is tearing down.
+    void (*abort)(sound_subsystem_t *subsystem);
 };
 
 /*
@@ -35,6 +44,17 @@ struct sound_subsystem_t {
  */
 typedef void (*sound_hda_backend_write_fn)(void *user_data, void *pcm_data, size_t size);
 
+/*
+ * Optional abort callback paired with sound_hda_backend_write_fn. When the
+ * HDA device is being removed (machine teardown), the stream worker may be
+ * blocked inside write_fn. abort_fn is invoked on the teardown thread and
+ * must cause any in-flight or future write_fn call on this sink to return
+ * promptly — typically by setting a flag that write_fn checks, or by
+ * signalling whatever the sink is blocked on (closing an fd, dropping a
+ * host PCM, etc.). Leave NULL for non-blocking sinks (ring buffers, etc.).
+ */
+typedef void (*sound_hda_backend_abort_fn)(void *user_data);
+
 // Internal use
 bool alsa_sound_init(sound_subsystem_t *sound);
 
@@ -49,12 +69,18 @@ PUBLIC pci_dev_t* sound_hda_init_auto(rvvm_machine_t* machine);
  *
  * When a non-NULL `write_fn` is supplied, the HDA device skips any
  * compiled-in backend and routes every PCM chunk through `write_fn`.
+ *
+ * `abort_fn` is optional. Supply it when `write_fn` can block; it is
+ * invoked during device removal to unblock any in-flight write so the
+ * stream worker can exit promptly. Pass NULL if `write_fn` never blocks.
  */
 PUBLIC pci_dev_t* sound_hda_init_ex(pci_bus_t* pci_bus,
                                     sound_hda_backend_write_fn write_fn,
+                                    sound_hda_backend_abort_fn abort_fn,
                                     void* user_data);
 PUBLIC pci_dev_t* sound_hda_init_auto_ex(rvvm_machine_t* machine,
                                          sound_hda_backend_write_fn write_fn,
+                                         sound_hda_backend_abort_fn abort_fn,
                                          void* user_data);
 
 #endif


### PR DESCRIPTION
Closes #208.

The `sound_hda_remove` fix from #207 halts the stream worker cooperatively, but the cooperation has two holes that still produce the UAF reported in #208. This PR closes both and adds a backend `abort()` hook so the fix doesn't stall teardown on blocking sinks.

### Root cause

`pci_func_send_intx_irq` crashes on a freed `pci_func_t*` when the stream worker outlives `rvvm_machine_free`. The halt path introduced in #207:

```c
atomic_store_uint32_relax(&stream->running, 0);
for (int i = 0; i < 200; i++) {
    if (!atomic_load_uint32_relax(&stream->worker_alive)) break;
    sleep_ms(5);
}
```

has two problems:

1. **The drain loop doesn't honour `running` promptly.** `sound_hda_stream_drain` checks `running` only in its outer `while`. Once a BDL pass starts, the inner `for (i = 0; i < total; ++i)` walks every entry with pacing (up to `lvi+1` × ~43 ms at 48 kHz mono S16) — several seconds of work after `running=0` is observable.
2. **The 1-second `worker_alive` cap creates a UAF window.** If the worker is still in its BDL pass past the cap, `sound_hda_remove` returns and the caller frees the PCI state. The worker then calls `pci_send_irq(hda->pci_func, 0)` → `pci_func_send_intx_irq` → SEGV_ACCERR on a remapped freed chunk. The prior comment framed the cap as a liveness guard with "worst outcome is a brief thread leak — not a use-after-free" — it's the UAF.

This is latent even without the ALSA backend since the paced BDL walk alone can outrun 1 s. In practice it reproduces most easily on a blocking host sink (PipeWire mid-xrun) where `snd_pcm_writei` parks the worker well past the cap.

### Fix (first commit — `sound-hda: Close UAF window in remove()'s worker halt`)

- Add a `running` check inside the inner BDL `for`, after the backend write and before pacing / IRQ dispatch. Worker returns from the drain within one backend call of `running=0`.
- Drop the 1-second cap in `sound_hda_remove`; wait unbounded on `worker_alive`. Log a one-shot `rvvm_warn` after 5 s as a diagnostic for a wedged backend.

Unbounded wait is safe because hanging on teardown is recoverable (the host notices and kills the process), while returning while the worker is still live and using `hda->pci_func` is the UAF.

### Backend abort hook (second commit — `sound-hda: Add backend abort hook so remove() can unblock a wedged sink`)

The unbounded wait turns a potential UAF into a potential hang when the backend's `write()` itself blocks (ALSA under PipeWire xrun, any IPC sink without an internal queue). To close that too:

- Add an optional `abort()` to `sound_subsystem_t`, called from `sound_hda_remove` before the `worker_alive` wait. Backends whose `write()` can block implement it; non-blocking backends leave it `NULL`.
- ALSA: `alsa_subsystem_t` gains an `aborted` flag checked at the top of the `snd_pcm_writei` retry loop. `alsa_sound_abort` sets the flag and calls `snd_pcm_drop`, forcing any in-flight `writei` to return `-EPIPE`. Without the flag the retry loop would `snd_pcm_prepare` + retry and re-block.
- `sound_hda_init_ex` / `_auto_ex` gain a matching `sound_hda_backend_abort_fn` parameter for library consumers with their own sinks.

With the abort hook in place, the 5 s diagnostic warning is effectively unreachable for well-behaved backends.

### Test plan

- [x] Linux x86_64 native build clean on GCC (default Makefile)
- [x] Pre-existing cases still work: mpg123 streaming playback, `aplay`, USE_ALSA=0 builds, USE_ALSA=1 with no consumer-supplied backend.
- [x] Reproducer from #208 (host app repeatedly destroys VMs while others stream): no SEGV after these commits; prior tip reproduced within minutes.
- [x] ALSA abort path: validated via PipeWire xrun + `rvvm_machine_free` during active mpg123 playback — teardown returns promptly, no hang, no crash.

### Notes

- The public API change is additive to the `_ex` variants introduced in #207. Callers passing `write_fn != NULL` from that PR need to add a third arg (`NULL` is fine for non-blocking sinks).
- The inner-loop `running` check uses `atomic_load_uint32_relax`; one relaxed atomic per BDL entry is negligible next to the backend write + pacing sleep.