### PR TITLE
riscv_csr: Set seed.OPST=ES16 to indicate success

### DIFF
--- a/src/riscv_csr.c
+++ b/src/riscv_csr.c
@@ -166,7 +166,7 @@ static inline bool riscv_csr_seed(rvvm_hart_t* vm, rvvm_uxlen_t* dest)
     if (riscv_csr_seed_enabled(vm)) {
         uint16_t seed = 0;
         rvvm_randombytes(&seed, sizeof(seed));
-        return riscv_csr_const(dest, seed);
+        return riscv_csr_const(dest, seed | CSR_SEED_OPST_ES16);
     }
     return false;
 }

--- a/src/riscv_csr.h
+++ b/src/riscv_csr.h
@@ -297,6 +297,8 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #define CSR_COUNTEREN_TM   0x2U
 #define CSR_COUNTEREN_IR   0x4U
 
+#define CSR_SEED_OPST_ES16 (2ULL << 30)
+
 /*
  * CSR Masks (For WARL behavior of CSRs)
  */


### PR DESCRIPTION
Previously, the OPST field was set to BIST (0), indicating that a Built-In Self-Test is running.

This makes SerenityOS boot in RVVM again, since we added Zkr support in https://github.com/SerenityOS/serenity/pull/26711 and don't have a timeout while polling the seed CSR at the moment.