### PR TITLE
tap_user: ignore ARP probes (sender 0.0.0.0) so DHCP DAD succeeds

### DIFF
--- a/src/devices/tap_user.c
+++ b/src/devices/tap_user.c
@@ -819,7 +819,8 @@ static void handle_arp(tap_dev_t* tap, const uint8_t* buffer, size_t size)
     uint8_t frame[ARPv4_HDR_SIZE + ETH2_HDR_SIZE];
     uint16_t ptype = read_uint16_be_m(buffer + 2);
     uint16_t oper  = read_uint16_be_m(buffer + 6);
-    if (oper == OP_REQUEST && ptype == ETH2_IPv4 && memcmp(buffer + 14, buffer + 24, 4) && memcmp(buffer + 24, CLIENT_IP, 4)) {
+    // Skip ARP probes (sender 0.0.0.0): replying makes the client's DHCP DAD see a phantom conflict and never take the lease
+    if (oper == OP_REQUEST && ptype == ETH2_IPv4 && memcmp(buffer + 14, buffer + 24, 4) && memcmp(buffer + 24, CLIENT_IP, 4) && memcmp(buffer + 14, "\0\0\0\0", 4)) {
         uint8_t* arp = create_eth_frame(tap, frame, ETH2_ARP);
         create_arp_frame(tap, arp, buffer + 24);
         eth_send(tap, frame, ARPv4_HDR_SIZE + ETH2_HDR_SIZE);


### PR DESCRIPTION
The user-mode ARP responder already skips gratuitous requests and requests for CLIENT_IP, but it still answers ARP probes: the sender 0.0.0.0 packets a client broadcasts during Duplicate Address Detection right after a DHCP OFFER.

Answering one makes the client read its own offered address as already owned, so it abandons the lease and loops through DISCOVER/DAD without ever coming up. There is no second host on the user-mode LAN, so a probe is unique by construction and never needs a reply.

One extra memcmp on the request path; everything that used to get answered still does. Built and ARP/DHCP exercised on an Alpine RISC-V guest, lease comes up clean.