### PR TITLE
tap_user: tidy handle_arp ARP-filter readability

### DIFF
--- a/src/devices/tap_user.c
+++ b/src/devices/tap_user.c
@@ -819,10 +819,20 @@ static void handle_arp(tap_dev_t* tap, const uint8_t* buffer, size_t size)
     uint8_t frame[ARPv4_HDR_SIZE + ETH2_HDR_SIZE];
     uint16_t ptype = read_uint16_be_m(buffer + 2);
     uint16_t oper  = read_uint16_be_m(buffer + 6);
-    // Skip ARP probes (sender 0.0.0.0): replying makes the client's DHCP DAD see a phantom conflict and never take the lease
-    if (oper == OP_REQUEST && ptype == ETH2_IPv4 && memcmp(buffer + 14, buffer + 24, 4) && memcmp(buffer + 24, CLIENT_IP, 4) && memcmp(buffer + 14, "\0\0\0\0", 4)) {
+    const uint8_t* sender_ip = buffer + 14;
+    const uint8_t* target_ip = buffer + 24;
+
+    // Answer IPv4 ARP requests, but stay silent for three cases:
+    //  - gratuitous ARP (sender == target)
+    //  - requests for the client's own address (target == CLIENT_IP)
+    //  - DAD probes (sender == 0.0.0.0): a reply makes the guest's DHCP
+    //    duplicate-address check see a phantom conflict and drop the lease
+    if (oper == OP_REQUEST && ptype == ETH2_IPv4
+        && memcmp(sender_ip, target_ip, PLEN_IPv4)
+        && memcmp(target_ip, CLIENT_IP, PLEN_IPv4)
+        && memcmp(sender_ip, net_ipv4_any_addr.ip, PLEN_IPv4)) {
         uint8_t* arp = create_eth_frame(tap, frame, ETH2_ARP);
-        create_arp_frame(tap, arp, buffer + 24);
+        create_arp_frame(tap, arp, target_ip);
         eth_send(tap, frame, ARPv4_HDR_SIZE + ETH2_HDR_SIZE);
     }
 }


### PR DESCRIPTION
Readability only, no behaviour change. Names the sender / target IP fields, uses PLEN_IPv4 for lengths, and compares the probe's sender against net_ipv4_any_addr.ip instead of a "\0\0\0\0" literal. handle_arp is cold and the locals fold away, so codegen is unchanged.