### PR TITLE
mtd-physmap: align public API with the implemented symbol

### DIFF
--- a/include/rvvm/rvvm_board.h
+++ b/include/rvvm/rvvm_board.h
@@ -345,17 +345,15 @@ static inline rvvm_pci_func_t* rvvm_bochs_display_init_auto(rvvm_machine_t* mach
  * however it may be used as a very simplistic storage device
  *
  * \param machine Machine handle
- * \param blk     Block device handle (Nullable)
  * \param addr    Base MMIO address
- * \param fw      Load guest firmware from this device on reset
+ * \param blk     Block device handle (Nullable)
  * \return        Region device handle or NULL
  *
  * This device is hot-removable via rvvm_region_free()
  */
-RVVM_PUBLIC rvvm_reg_dev_t* rvvm_mtd_ram_init(rvvm_machine_t* machine,    /**/
-                                              rvvm_blk_dev_t* blk, /**/
-                                              rvvm_addr_t     addr,     /**/
-                                              bool            fw);
+RVVM_PUBLIC rvvm_reg_dev_t* mtd_ram_init_blk(rvvm_machine_t* machine, /**/
+                                             rvvm_addr_t     addr,    /**/
+                                             rvvm_blk_dev_t* blk);
 
 /**
  * Attach NVMe block device to the machine (PCI-based)

--- a/src/devices/mtd-physmap.h
+++ b/src/devices/mtd-physmap.h
@@ -21,19 +21,19 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
  * different firmware into the board memory chip
  */
 
-RVVM_PUBLIC rvvm_reg_dev_t* rvvm_mtd_ram_init(rvvm_machine_t* machine, /**/
-                                              rvvm_blk_dev_t* blk,     /**/
-                                              rvvm_addr_t     addr,    /**/
-                                              bool            fw);
+RVVM_PUBLIC rvvm_reg_dev_t* mtd_ram_init_blk(rvvm_machine_t* machine, /**/
+                                             rvvm_addr_t     addr,    /**/
+                                             rvvm_blk_dev_t* blk);
 
 static inline rvvm_reg_dev_t* mtd_physmap_init(rvvm_machine_t* machine, /**/
                                                const char*     image,   /**/
                                                rvvm_addr_t     addr,    /**/
                                                bool            fw)
 {
+    (void)fw;
     rvvm_blk_dev_t* blk = rvvm_blk_open(image, NULL, RVVM_BLK_RW);
     if (blk) {
-        return rvvm_mtd_ram_init(machine, blk, addr, fw);
+        return mtd_ram_init_blk(machine, addr, blk);
     }
     return NULL;
 }


### PR DESCRIPTION
The public headers declare `rvvm_mtd_ram_init(machine, blk, addr, fw)`, but `mtd-physmap.c` only implements `mtd_ram_init_blk(machine, addr, blk)`. The declared symbol is never defined, so:

- the inline `mtd_physmap_init()` wrapper in `mtd-physmap.h` calls `rvvm_mtd_ram_init()`, and
- any external consumer that includes the header and links against `librvvm.so` fails with `undefined symbol: rvvm_mtd_ram_init`.

Align the public API with what actually ships: drop the dead `rvvm_mtd_ram_init` declaration, expose the real `mtd_ram_init_blk` in `rvvm_board.h`, and route the `mtd_physmap_init` wrapper through it. The `fw` parameter the old signature carried was already unused by the implementation, so the wrapper now ignores it (`(void)fw`).

No behaviour change for in-tree callers — `mtd_physmap_init`'s own signature is unchanged; this only fixes the symbol it resolves to.
