### PR TITLE
riscv_fpu: correct RMM rounding, honor static rounding modes, optimize FP dispatch

### DIFF
--- a/src/cpu/riscv_fpu.c
+++ b/src/cpu/riscv_fpu.c
@@ -54,43 +54,160 @@ static const uint32_t riscv_fli_table[32] = {
     0x7FC00000UL, // Canonical NaN
 };
 
-static void riscv_prepare_rmm(rvvm_hart_t* vm, const uint32_t insn, const size_t rs1, const size_t rs2)
+/*
+ * RMM (round to nearest, ties to max magnitude) == IEEE 754 roundTiesToAway.
+ *
+ * The host FPU has no such mode, so when frm == RMM the host is left in
+ * round-to-nearest-even (see fpu_set_rounding_mode()). RNE and roundTiesToAway
+ * produce identical results EXCEPT on an exact halfway tie, where RNE rounds to
+ * even and roundTiesToAway rounds to the larger-magnitude neighbour.
+ *
+ * So we compute the op in RNE, recover the EXACT rounding error via the library's
+ * error-free transforms (TwoSum / TwoProduct), and only when that error is
+ * exactly half a ULP away from zero do we step the result outward by one ULP.
+ * (The previous implementation rounded toward +/-inf unconditionally, which is
+ * correct on ties but wrong for every inexact non-tie. See issue #204.)
+ *
+ * fadd/fsub/fmul use riscv_rmm_apply (below). fsqrt never needs a fixup: a square
+ * root is irrational unless exact, and its result is always normal (the square
+ * root of even the smallest subnormal is ~2^-75), so RNE == roundTiesToAway. A
+ * *normally-rounded* quotient is likewise never an exact halfway case — but a
+ * *subnormal* quotient has reduced precision and CAN land exactly on a tie, so
+ * fdiv gets a dedicated subnormal fixup (riscv_rmm_div_apply).
+ *
+ * The error-free transforms run only for a finite result, and the per-op wrappers
+ * (riscv_rmm_add/mul/div) snapshot and restore the exception flags around them:
+ * TwoSum/TwoProduct do raw host arithmetic whose intermediate steps can raise
+ * spurious exceptions (inf-inf -> NV, near-FLT_MAX -> OF) that must not leak into
+ * fflags. The genuine flags are already set by the base op.
+ */
+static forceinline fpu_f32_t riscv_rmm_apply_f32(fpu_f32_t n, fpu_f32_t err)
 {
-    bool neg = false;
-
-    // Decide the sign of the output
-    switch (insn & 0xFE000000UL) {
-        case 0x00000000UL: // fadd.s
-            neg = fpu_signbit32(fpu_add32(riscv_view_s(vm, rs1), riscv_view_s(vm, rs2)));
-            break;;
-        case 0x02000000UL: // fadd.d
-            neg = fpu_signbit64(fpu_add64(riscv_view_d(vm, rs1), riscv_view_d(vm, rs2)));
-            break;
-        case 0x08000000UL: // fsub.s
-            neg = fpu_signbit32(fpu_sub32(riscv_view_s(vm, rs1), riscv_view_s(vm, rs2)));
-            break;
-        case 0x0A000000UL: // fsub.d
-            neg = fpu_signbit64(fpu_sub64(riscv_view_d(vm, rs1), riscv_view_d(vm, rs2)));
-            break;
-        case 0x10000000UL: // fmul.s
-        case 0x18000000UL: // fdiv.s
-            neg = fpu_signbit32(riscv_view_s(vm, rs1)) != fpu_signbit32(riscv_view_s(vm, rs2));
-            break;
-        case 0x12000000UL: // fmul.d
-        case 0x1A000000UL: // fdiv.d
-            neg = fpu_signbit64(riscv_view_d(vm, rs1)) != fpu_signbit64(riscv_view_d(vm, rs2));
-            break;
-        default:
-            neg = fpu_signbit64(riscv_view_d(vm, rs1));
-            break;
+    const uint32_t un = fpu_bit_f32_to_u32(n);
+    const uint32_t ue = fpu_bit_f32_to_u32(err);
+    // Skip exact results (err == +/-0) and errors pointing toward zero: in both
+    // cases RNE already delivers the roundTiesToAway value.
+    if ((ue << 1) == 0 || (un >> 31) != (ue >> 31)) {
+        return n;
     }
-
-    // Round to positive/negative infinity based on the result sign
-    if (neg) {
-        fpu_set_rounding_mode(FPU_LIB_ROUND_DN);
-    } else {
-        fpu_set_rounding_mode(FPU_LIB_ROUND_UP);
+    // n + 1 ULP toward larger magnitude, and the exact gap to it.
+    const fpu_f32_t away    = fpu_bit_u32_to_f32(un + 1);
+    const fpu_f32_t spacing = fpu_sub32(away, n);  // exact: adjacent floats
+    // Tie iff the exact result is the midpoint, i.e. 2*err == spacing.
+    if (fpu_is_bit_equal32(fpu_add32(err, err), spacing)) {
+        return away;
     }
+    return n;
+}
+
+static forceinline fpu_f64_t riscv_rmm_apply_f64(fpu_f64_t n, fpu_f64_t err)
+{
+    const uint64_t un = fpu_bit_f64_to_u64(n);
+    const uint64_t ue = fpu_bit_f64_to_u64(err);
+    if ((ue << 1) == 0 || (un >> 63) != (ue >> 63)) {
+        return n;
+    }
+    const fpu_f64_t away    = fpu_bit_u64_to_f64(un + 1);
+    const fpu_f64_t spacing = fpu_sub64(away, n);
+    if (fpu_is_bit_equal64(fpu_add64(err, err), spacing)) {
+        return away;
+    }
+    return n;
+}
+
+// roundTiesToAway fixup for fadd/fsub (fsub passes b negated). Flag-isolated.
+static forceinline fpu_f32_t riscv_rmm_add_f32(fpu_f32_t n, fpu_f32_t a, fpu_f32_t b)
+{
+    if (unlikely(!fpu_is_finite32(n))) {
+        return n;
+    }
+    const uint32_t exc = fpu_get_exceptions();
+    const fpu_f32_t r  = riscv_rmm_apply_f32(n, fpu_add_error32(n, a, b));
+    fpu_set_exceptions(exc);
+    return r;
+}
+
+static forceinline fpu_f64_t riscv_rmm_add_f64(fpu_f64_t n, fpu_f64_t a, fpu_f64_t b)
+{
+    if (unlikely(!fpu_is_finite64(n))) {
+        return n;
+    }
+    const uint32_t exc = fpu_get_exceptions();
+    const fpu_f64_t r  = riscv_rmm_apply_f64(n, fpu_add_error64(n, a, b));
+    fpu_set_exceptions(exc);
+    return r;
+}
+
+// roundTiesToAway fixup for fmul. Flag-isolated.
+static forceinline fpu_f32_t riscv_rmm_mul_f32(fpu_f32_t n, fpu_f32_t a, fpu_f32_t b)
+{
+    if (unlikely(!fpu_is_finite32(n))) {
+        return n;
+    }
+    const uint32_t exc = fpu_get_exceptions();
+    const fpu_f32_t r  = riscv_rmm_apply_f32(n, fpu_mul_error32(n, a, b));
+    fpu_set_exceptions(exc);
+    return r;
+}
+
+static forceinline fpu_f64_t riscv_rmm_mul_f64(fpu_f64_t n, fpu_f64_t a, fpu_f64_t b)
+{
+    if (unlikely(!fpu_is_finite64(n))) {
+        return n;
+    }
+    const uint32_t exc = fpu_get_exceptions();
+    const fpu_f64_t r  = riscv_rmm_apply_f64(n, fpu_mul_error64(n, a, b));
+    fpu_set_exceptions(exc);
+    return r;
+}
+
+/*
+ * roundTiesToAway fixup for fdiv. Only a subnormal (or zero) quotient can be an
+ * exact tie; a normal quotient never is, so the common path returns immediately
+ * (non-finite results also have a non-zero exponent field and return unchanged).
+ *
+ * For a subnormal result the exact residual rho = a - n*b is representable, so
+ * fma(-n, b, a) recovers it exactly. The true quotient is n + rho/b, so it is the
+ * exact midpoint (a tie, rounded away) iff 2*rho == gap*b, where gap = away - n
+ * (= +/- the subnormal step). |rho| <= |b|*2^-1075, so every value below stays in
+ * range and exact. Flag-isolated, as the residual machinery can raise spurious
+ * exceptions.
+ */
+static forceinline fpu_f32_t riscv_rmm_div_apply_f32(fpu_f32_t n, fpu_f32_t a, fpu_f32_t b)
+{
+    if (likely(fpu_bit_f32_to_u32(n) & FPU_LIB_FP32_EXPONENT_MASK)) {
+        return n;  // normal / inf / nan: RNE already == roundTiesToAway
+    }
+    const uint32_t  exc  = fpu_get_exceptions();
+    const fpu_f32_t rho  = fpu_fma32(fpu_neg32(n), b, a);  // exact residual a - n*b
+    const fpu_f32_t away = fpu_bit_u32_to_f32(fpu_bit_f32_to_u32(n) + 1);
+    const fpu_f32_t gap  = fpu_sub32(away, n);             // +/- 2^-149, exact
+    // Tie iff 2*rho == gap*b, evaluated in fp64 where both sides are exact
+    // (operands widen losslessly and gap*b ~ 2^-22 stays well inside the range).
+    const fpu_f64_t two_rho = fpu_add64(fpu_fcvt_f32_to_f64(rho), fpu_fcvt_f32_to_f64(rho));
+    const fpu_f64_t gap_b   = fpu_mul64(fpu_fcvt_f32_to_f64(gap), fpu_fcvt_f32_to_f64(b));
+    const fpu_f32_t r       = fpu_is_bit_equal64(two_rho, gap_b) ? away : n;
+    fpu_set_exceptions(exc);
+    return r;
+}
+
+static forceinline fpu_f64_t riscv_rmm_div_apply_f64(fpu_f64_t n, fpu_f64_t a, fpu_f64_t b)
+{
+    if (likely(fpu_bit_f64_to_u64(n) & FPU_LIB_FP64_EXPONENT_MASK)) {
+        return n;
+    }
+    const uint32_t  exc  = fpu_get_exceptions();
+    const fpu_f64_t rho  = fpu_fma64(fpu_neg64(n), b, a);
+    const fpu_f64_t away = fpu_bit_u64_to_f64(fpu_bit_f64_to_u64(n) + 1);
+    const fpu_f64_t gap  = fpu_sub64(away, n);             // +/- 2^-1074, exact
+    // fp64 has no wider type; gap*b underflows, so rescale 2*rho == gap*b by the
+    // gap magnitude (2^1074) as two exact power-of-two steps: rho*2^1075 == +/-b.
+    const fpu_f64_t scaled = fpu_mul64(fpu_mul64(rho, fpu_bit_u64_to_f64(0x7FE0000000000000ULL)),  // 2^1023
+                                       fpu_bit_u64_to_f64(0x4330000000000000ULL));                 // 2^52
+    const fpu_f64_t target = (fpu_bit_f64_to_u64(gap) >> 63) ? fpu_neg64(b) : b;
+    const fpu_f64_t r      = fpu_is_bit_equal64(scaled, target) ? away : n;
+    fpu_set_exceptions(exc);
+    return r;
 }
 
 slow_path func_opt_size void riscv_emulate_f_opc_op(rvvm_hart_t* vm, const uint32_t insn)
@@ -102,39 +219,62 @@ slow_path func_opt_size void riscv_emulate_f_opc_op(rvvm_hart_t* vm, const uint3
 
     if (likely(riscv_fpu_is_enabled(vm))) {
 
-        if (unlikely(vm->csr.fcsr >> 5 == 0x04)) {
-            // Handle RMM rounding
-            riscv_prepare_rmm(vm, insn, rs1, rs2);
-        }
+        // roundTiesToAway is active for dynamic-rounding ops while frm == RMM; the
+        // fadd/fsub/fmul/fdiv cases below apply the exact ties-away fixup when set.
+        const bool rmm = unlikely(vm->csr.fcsr >> 5 == 0x04) && rm == 0x07;
 
         switch (insn & 0xFE007000UL) {
             /*
              * FPU computations
              */
-            case RISCV_FPU_GEN_RM_CASES(0x00000000UL): // fadd.s
-                riscv_emit_s(vm, rds, fpu_add32(riscv_view_s(vm, rs1), riscv_view_s(vm, rs2)));
+            case RISCV_FPU_GEN_RM_CASES(0x00000000UL): { // fadd.s
+                const fpu_f32_t a = riscv_view_s(vm, rs1), b = riscv_view_s(vm, rs2);
+                const fpu_f32_t n = fpu_add32(a, b);
+                riscv_emit_s(vm, rds, rmm ? riscv_rmm_add_f32(n, a, b) : n);
                 return;
-            case RISCV_FPU_GEN_RM_CASES(0x02000000UL): // fadd.d
-                riscv_emit_d(vm, rds, fpu_add64(riscv_view_d(vm, rs1), riscv_view_d(vm, rs2)));
+            }
+            case RISCV_FPU_GEN_RM_CASES(0x02000000UL): { // fadd.d
+                const fpu_f64_t a = riscv_view_d(vm, rs1), b = riscv_view_d(vm, rs2);
+                const fpu_f64_t n = fpu_add64(a, b);
+                riscv_emit_d(vm, rds, rmm ? riscv_rmm_add_f64(n, a, b) : n);
                 return;
-            case RISCV_FPU_GEN_RM_CASES(0x08000000UL): // fsub.s
-                riscv_write_s(vm, rds, fpu_sub32(riscv_view_s(vm, rs1), riscv_view_s(vm, rs2)));
+            }
+            case RISCV_FPU_GEN_RM_CASES(0x08000000UL): { // fsub.s
+                const fpu_f32_t a = riscv_view_s(vm, rs1), b = riscv_view_s(vm, rs2);
+                const fpu_f32_t n = fpu_sub32(a, b);
+                riscv_write_s(vm, rds, rmm ? riscv_rmm_add_f32(n, a, fpu_neg32(b)) : n);
                 return;
-            case RISCV_FPU_GEN_RM_CASES(0x0A000000UL): // fsub.d
-                riscv_write_d(vm, rds, fpu_sub64(riscv_view_d(vm, rs1), riscv_view_d(vm, rs2)));
+            }
+            case RISCV_FPU_GEN_RM_CASES(0x0A000000UL): { // fsub.d
+                const fpu_f64_t a = riscv_view_d(vm, rs1), b = riscv_view_d(vm, rs2);
+                const fpu_f64_t n = fpu_sub64(a, b);
+                riscv_write_d(vm, rds, rmm ? riscv_rmm_add_f64(n, a, fpu_neg64(b)) : n);
                 return;
-            case RISCV_FPU_GEN_RM_CASES(0x10000000UL): // fmul.s
-                riscv_emit_s(vm, rds, fpu_mul32(riscv_view_s(vm, rs1), riscv_view_s(vm, rs2)));
+            }
+            case RISCV_FPU_GEN_RM_CASES(0x10000000UL): { // fmul.s
+                const fpu_f32_t a = riscv_view_s(vm, rs1), b = riscv_view_s(vm, rs2);
+                const fpu_f32_t n = fpu_mul32(a, b);
+                riscv_emit_s(vm, rds, rmm ? riscv_rmm_mul_f32(n, a, b) : n);
                 return;
-            case RISCV_FPU_GEN_RM_CASES(0x12000000UL): // fmul.d
-                riscv_emit_d(vm, rds, fpu_mul64(riscv_view_d(vm, rs1), riscv_view_d(vm, rs2)));
+            }
+            case RISCV_FPU_GEN_RM_CASES(0x12000000UL): { // fmul.d
+                const fpu_f64_t a = riscv_view_d(vm, rs1), b = riscv_view_d(vm, rs2);
+                const fpu_f64_t n = fpu_mul64(a, b);
+                riscv_emit_d(vm, rds, rmm ? riscv_rmm_mul_f64(n, a, b) : n);
                 return;
-            case RISCV_FPU_GEN_RM_CASES(0x18000000UL): // fdiv.s
-                riscv_emit_s(vm, rds, fpu_div32(riscv_view_s(vm, rs1), riscv_view_s(vm, rs2)));
+            }
+            case RISCV_FPU_GEN_RM_CASES(0x18000000UL): { // fdiv.s
+                const fpu_f32_t a = riscv_view_s(vm, rs1), b = riscv_view_s(vm, rs2);
+                const fpu_f32_t n = fpu_div32(a, b);
+                riscv_emit_s(vm, rds, rmm ? riscv_rmm_div_apply_f32(n, a, b) : n);
                 return;
-            case RISCV_FPU_GEN_RM_CASES(0x1A000000UL): // fdiv.d
-                riscv_emit_d(vm, rds, fpu_div64(riscv_view_d(vm, rs1), riscv_view_d(vm, rs2)));
+            }
+            case RISCV_FPU_GEN_RM_CASES(0x1A000000UL): { // fdiv.d
+                const fpu_f64_t a = riscv_view_d(vm, rs1), b = riscv_view_d(vm, rs2);
+                const fpu_f64_t n = fpu_div64(a, b);
+                riscv_emit_d(vm, rds, rmm ? riscv_rmm_div_apply_f64(n, a, b) : n);
                 return;
+            }
             case RISCV_FPU_GEN_RM_CASES(0x58000000UL): // fsqrt.s
                 if (likely(!rs2)) {
                     riscv_emit_s(vm, rds, fpu_sqrt32(riscv_view_s(vm, rs1)));

--- a/src/cpu/riscv_fpu.c
+++ b/src/cpu/riscv_fpu.c
@@ -210,7 +210,7 @@ static forceinline fpu_f64_t riscv_rmm_div_apply_f64(fpu_f64_t n, fpu_f64_t a, f
     return r;
 }
 
-static slow_path func_opt_size void riscv_emulate_f_opc_op_impl(rvvm_hart_t* vm, const uint32_t insn, const bool rmm)
+static slow_path void riscv_emulate_f_opc_op_impl(rvvm_hart_t* vm, const uint32_t insn, const bool rmm)
 {
     const size_t   rds = bit_ext_u32(insn, 7, 5);
     const uint32_t rm  = bit_ext_u32(insn, 12, 3);
@@ -551,7 +551,7 @@ static slow_path func_opt_size void riscv_emulate_f_opc_op_impl(rvvm_hart_t* vm,
  * in RNE. funct3 == rm only carries a rounding mode on rounding-capable ops, so
  * this never misfires on fsgnj/fcmp/fclass/fmv.
  */
-slow_path func_opt_size void riscv_emulate_f_opc_op(rvvm_hart_t* vm, const uint32_t insn)
+slow_path void riscv_emulate_f_opc_op(rvvm_hart_t* vm, const uint32_t insn)
 {
     const uint32_t rm  = bit_ext_u32(insn, 12, 3);
     const uint32_t frm = vm->csr.fcsr >> 5;

--- a/src/cpu/riscv_fpu.c
+++ b/src/cpu/riscv_fpu.c
@@ -210,7 +210,7 @@ static forceinline fpu_f64_t riscv_rmm_div_apply_f64(fpu_f64_t n, fpu_f64_t a, f
     return r;
 }
 
-slow_path func_opt_size void riscv_emulate_f_opc_op(rvvm_hart_t* vm, const uint32_t insn)
+static slow_path func_opt_size void riscv_emulate_f_opc_op_impl(rvvm_hart_t* vm, const uint32_t insn, const bool rmm)
 {
     const size_t   rds = bit_ext_u32(insn, 7, 5);
     const uint32_t rm  = bit_ext_u32(insn, 12, 3);
@@ -218,10 +218,6 @@ slow_path func_opt_size void riscv_emulate_f_opc_op(rvvm_hart_t* vm, const uint3
     const size_t   rs2 = bit_ext_u32(insn, 20, 5);
 
     if (likely(riscv_fpu_is_enabled(vm))) {
-
-        // roundTiesToAway is active for dynamic-rounding ops while frm == RMM; the
-        // fadd/fsub/fmul/fdiv cases below apply the exact ties-away fixup when set.
-        const bool rmm = unlikely(vm->csr.fcsr >> 5 == 0x04) && rm == 0x07;
 
         switch (insn & 0xFE007000UL) {
             /*
@@ -544,6 +540,34 @@ slow_path func_opt_size void riscv_emulate_f_opc_op(rvvm_hart_t* vm, const uint3
     }
 
     riscv_illegal_insn(vm, insn);
+}
+
+/*
+ * RISC-V selects the rounding mode either dynamically (the frm CSR, when the
+ * instruction's rm field is DYN) or statically (the rm field itself). The host
+ * FPU tracks frm, so a static rm field that differs from frm must be applied
+ * around the op. RMM has no host mode at all and is synthesized in RNE by the
+ * fixups above (riscv_rmm_apply / riscv_rmm_div_apply), so its sub-ops must run
+ * in RNE. funct3 == rm only carries a rounding mode on rounding-capable ops, so
+ * this never misfires on fsgnj/fcmp/fclass/fmv.
+ */
+slow_path func_opt_size void riscv_emulate_f_opc_op(rvvm_hart_t* vm, const uint32_t insn)
+{
+    const uint32_t rm  = bit_ext_u32(insn, 12, 3);
+    const uint32_t frm = vm->csr.fcsr >> 5;
+    // Effective rounding mode: a static rm field overrides the dynamic frm CSR.
+    const uint32_t eff = (rm == 0x07) ? frm : rm;
+    const bool     rmm = (eff == 0x04);
+    // Override the host mode when synthesizing RMM (run sub-ops in RNE) or when a
+    // static rm field selects a host-native mode other than the one frm left set.
+    if (unlikely(rmm || (rm != 0x07 && eff != frm))) {
+        const uint32_t host = fpu_get_rounding_mode();
+        fpu_set_rounding_mode(rmm ? FPU_LIB_ROUND_NE : eff);
+        riscv_emulate_f_opc_op_impl(vm, insn, rmm);
+        fpu_set_rounding_mode(host);
+    } else {
+        riscv_emulate_f_opc_op_impl(vm, insn, false);
+    }
 }
 
 #endif


### PR DESCRIPTION
## Summary

Fixes #204, and supersedes #234 and #235 (folded in here as separate commits — see below). Three related changes to the scalar FP interpreter (`riscv_emulate_f_opc_op`), each its own commit:

1. **`correct RMM rounding to roundTiesToAway`** — the actual #204 fix.
2. **`honor the static rounding-mode field`** — rounding modes encoded in the instruction's `rm` field, not just the dynamic `frm` CSR (was #235).
3. **`don't size-optimize the FP op dispatch`** — drop `func_opt_size` from the dispatch (was #234). This is what makes the whole thing a net **~2× FP speedup** over `staging` despite the extra rounding-mode work.

The three are coupled by perf (see Benchmarks), which is why they ship together.

---

## 1. Correct RMM rounding

RMM (IEEE 754 `roundTiesToAway`) was emulated as "always round away from zero" (`riscv_prepare_rmm`), which is correct only on an exact halfway tie and wrong for every other inexact result — e.g. `1.0f + 2⁻²⁵` returned `1.0000001f` instead of `1.0f`.

`roundTiesToAway` differs from the host's round-to-nearest-even **only** on an exact tie. So we compute the op in RNE, recover the **exact** rounding error via the library's existing error-free transforms (`fpu_add_error*` / `fpu_mul_error*` — TwoSum / TwoProduct), and step one ULP outward only when that error is exactly half a ULP away from zero.

Two corrections over the original version of this patch, both surfaced by the conformance work below:

- **Flag isolation.** The error-free transforms do raw host arithmetic whose *intermediate* steps can raise spurious exceptions (`inf − inf` → `NV`, a term near `FLT_MAX` → `OF`) even when the final result is finite. Those must not leak into `fflags` — the genuine flags are already set by the base op. The per-op fixups (`riscv_rmm_add/mul/div`) now snapshot and restore the exception state around the transform, and only run it for a finite result.
- **Subnormal-quotient ties.** The original claim "division never produces an exact tie" holds only for *normal* quotients. A **subnormal** quotient has reduced precision and *can* land exactly on a tie (e.g. `−2⁻¹⁵⁰` under RMM must give `−2⁻¹⁴⁹`, not `−0`). `fdiv` now gets a dedicated subnormal fixup using the exact residual `ρ = fma(−n, b, a)`: it is a tie iff `2·ρ == gap·b`, evaluated exactly (in fp64 for f32; via two exact power-of-two scalings for f64, since the residual is bounded by `|b|·2⁻¹⁰⁷⁵`). `fsqrt` genuinely never needs it — `sqrt` of even the smallest subnormal is ~`2⁻⁷⁵`, always normal.

## 2. Honor the static rounding-mode field

RVVM only ever drove the host rounding mode from the dynamic `frm` CSR; a static `rm` field on an arithmetic op (`fadd.s …,rtz` / `…,rmm` / etc.) was silently computed in whatever mode `frm` left set. The dispatch is split into a thin wrapper + `_impl(…, bool rmm)`: the wrapper computes the effective mode (`rm == DYN ? frm : rm`), and overrides the host mode around the op only when needed — synthesizing RMM in RNE, or applying a static host-native mode (`rne/rtz/rdn/rup`) that differs from `frm`. The common dynamic path is untouched. `funct3 == rm` only carries a rounding mode on rounding-capable ops, so this never misfires on `fsgnj`/`fcmp`/`fclass`/`fmv`.

## 3. Don't size-optimize the FP op dispatch

`riscv_emulate_f_opc_op` was tagged `func_opt_size` (`-Oz`), but rvjit does not emit FP, so **every** guest FP instruction is interpreted through this "slow path" — it is hot for any FP workload. Dropping the size attribute lets it optimize normally; `slow_path` (cold) is kept.

---

## Validation

**MPFR vector oracle** — harness [`rvvm-hal/examples/rmm-test`](https://github.com/SolAstrius/rvvm-hal/tree/master/examples/rmm-test) (bare-metal RVVM firmware; [main.c](https://github.com/SolAstrius/rvvm-hal/blob/master/examples/rmm-test/main.c), MPFR generator [gen_mpfr.c](https://github.com/SolAstrius/rvvm-hal/blob/master/examples/rmm-test/gen_mpfr.c), baked [vectors.inc](https://github.com/SolAstrius/rvvm-hal/blob/master/examples/rmm-test/vectors.inc)). roundTiesToAway is synthesized from MPFR's directed rounding + an exact-midpoint compare (MPFR has no native ties-away mode). The generator computes `double`-exact ground truth for f32 `+ − ×` (no circular reference). 1503 vectors across all five ops in f32 and f64 — subnormals, the normal/subnormal boundary, infinities, NaNs — each run **twice**: once with `frm = RMM` (dynamic) and once with a static `,rmm` suffix, plus a check that a *directed* `frm` survives a static-`,rmm` op (host mode restored). **3006/3006 + restore pass.** 40M random f32 division pairs confirmed zero normal-range ties.

**SerenityOS** `Tests/LibC/TestFenv` now passes `float_round_to_max_magnitude` and `save_restore_round` on a riscv64 guest — the cases originally reported in #204 — booting the nightly image end-to-end.

**RISC-V architectural conformance** (riscv-arch-test / ACT4, Spike reference). The full harness — DUT config, a signature-region UART dump, the per-failure diagnostic, and the categorized analysis — is in [`SolAstrius/rvvm-conformance`](https://github.com/SolAstrius/rvvm-conformance), reproducible via a pinned Nix dev shell on NixOS / nix-darwin / any Linux with Nix:

```sh
nix develop github:SolAstrius/rvvm-conformance
./setup.sh                                  # clone+pin suite, gem home, z3 wired by the shell
./run.sh F,D,I,M  /path/to/rvvm_arm64
```

Pass counts on this build vs `staging`:

| ext | staging | this PR |
|-----|---------|---------|
| I   | 51/51   | 51/51   |
| M   | 13/13   | 13/13   |
| F   | 13/82   | **22/82** |
| D   | 24/114  | **32/114** |

+17 from the rounding-mode fixes (the directed-rounding and subnormal-tie sub-cases, and the spurious-flag regression that this PR's flag isolation removes). The remaining F/D failures are **pre-existing, independent** gaps confirmed not caused by these changes — NaN-result canonicalization on `fadd/fmul/fdiv` (host payload vs canonical NaN), `fcvt`-to-int inexact-flag handling, and the FMA family (NaN canonicalization + rounding-mode + invalid-flag). Each is a separate follow-up; the ACT4 self-check pinpoints them per-instruction.

## Benchmarks

Both benchmarks are bare-metal RVVM firmwares: [`rvvm-hal/examples/fp-bench`](https://github.com/SolAstrius/rvvm-hal/tree/master/examples/fp-bench) (FP-op throughput) and [`rvvm-hal/examples/linpack`](https://github.com/SolAstrius/rvvm-hal/tree/master/examples/linpack) (LINPACK LU, MFLOPS). aarch64 host, fp-bench tight loops, ticks — lower is faster:

| op | staging | this PR | speedup |
|----|---------|---------|---------|
| addmul | 20.7M | 11.8M | ~1.75× |
| div    | 13.5M |  6.5M | ~2.07× |
| sqrt   | 31.1M | 13.5M | ~2.3×  |

Commit 1 alone is perf-neutral-to-better than `staging` (it removes the per-op `riscv_prepare_rmm` host-mode churn). Commit 2 (static rounding) adds a small per-op cost from the wrapper. Commit 3 (`func_opt_size` drop) more than pays for everything — net ~2× over `staging`. On a realistic mixed workload (LINPACK LU, double) the gain is ~3%, since the integer index/loop/memory ops are JIT-compiled and dominate; the 2× shows only where the FP handler dominates. Code size: the dispatch grows ~1.6 KB `__text` (+0.67%) from dropping `-Oz`.

## What was explored / left out

- An earlier **wrapper-based** static-rounding rework that added a real per-op call regressed FP throughput; the shipped form keeps the common dynamic path on a tail-called `_impl` so only the rare static-override path pays.
- The error-free-transform approach was chosen over re-rounding in higher precision because the library already ships TwoSum/TwoProduct and they give the exact tie decision directly; the subnormal `fdiv` case is the one place a residual+rescale is needed.
- Static `rm` is now honored for *all* modes (rtz/rdn/rup/rmm), not only RMM as in the original #235.
- Out of scope (separate PRs, all pre-existing): NaN-result canonicalization, `fcvt`-to-int flags, and the FMA family.
