### PR TITLE
riscv_fpu: don't size-optimize the FP op dispatch

### DIFF
--- a/src/cpu/riscv_fpu.c
+++ b/src/cpu/riscv_fpu.c
@@ -93,7 +93,7 @@ static void riscv_prepare_rmm(rvvm_hart_t* vm, const uint32_t insn, const size_t
     }
 }
 
-slow_path func_opt_size void riscv_emulate_f_opc_op(rvvm_hart_t* vm, const uint32_t insn)
+slow_path void riscv_emulate_f_opc_op(rvvm_hart_t* vm, const uint32_t insn)
 {
     const size_t   rds = bit_ext_u32(insn, 7, 5);
     const uint32_t rm  = bit_ext_u32(insn, 12, 3);


### PR DESCRIPTION
## Summary

`riscv_emulate_f_opc_op` — the interpreter's OP-FP dispatch (fadd/fsub/fmul/fdiv/fsqrt + conversions) — is tagged `func_opt_size`, which compiles it for size (`Oz`/`minsize`) instead of the project default `-O2`. But the rvjit backend does not emit floating-point yet, so **every** guest FP instruction is handled here — this "slow path" is actually hot for any FP workload. Dropping the size attribute lets the compiler optimize it normally.

## Change

One line: `slow_path func_opt_size` → `slow_path`. The `slow_path` (cold/`preserve_most`) marking is kept.

## Benchmarks (aarch64 host, this dispatch only)

Pure FP-op throughput (tight loops, 40M iters, time-CSR ticks, lower = faster):

| op mix | size-opt (before) | normal (after) | speedup |
|---|---|---|---|
| fadd/fsub/fmul | 24.8M | 11.6M | ~2.1× |
| fdiv | 16.1M | 6.3M | ~2.6× |
| fsqrt | 37.2M | 14.0M | ~2.7× |

Realistic mixed FP (LINPACK 100×100 LU, double):

| | before | after |
|---|---|---|
| MFLOPS | 106 | 109 (~+3%) |

The realistic gain is modest (~3%): in mixed code the integer index/loop/memory ops are JIT-compiled and dominate, so only the FP-handler fraction shrinks. The 2× shows up only when FP-handler time dominates. `O3` gives nothing beyond `O2`.

## Size

Function grows ~1.4 KB (`riscv_emulate_f_opc_op`: 4648 → 6004 bytes); total `__text` +1.6 KB (+0.67%). On this arm64 build the on-disk binary rounds up by one 16 KB page; on 4 KB-page targets the on-disk delta is correspondingly smaller.

Tradeoff is yours to weigh — modest real-world FP gain for ~1.6 KB of code. Benchmarks (`fp-bench`, `linpack`) are bare-metal RVVM firmwares, available on request.
