### PR TITLE
fpu: canonicalize NaN results of fadd/fmul/fdiv and fused ops

### DIFF
--- a/src/cpu/riscv_fpu.c
+++ b/src/cpu/riscv_fpu.c
@@ -140,10 +140,10 @@ static slow_path void riscv_emulate_f_opc_op_impl(rvvm_hart_t* vm, const uint32_
              * FPU computations
              */
             case RISCV_FPU_GEN_RM_CASES(0x00000000UL): // fadd.s
-                riscv_emit_s(vm, rds, fpu_add32(riscv_read_s(vm, rs1), riscv_read_s(vm, rs2)));
+                riscv_write_s(vm, rds, fpu_add32(riscv_read_s(vm, rs1), riscv_read_s(vm, rs2)));
                 return;
             case RISCV_FPU_GEN_RM_CASES(0x02000000UL): // fadd.d
-                riscv_emit_d(vm, rds, fpu_add64(riscv_view_d(vm, rs1), riscv_view_d(vm, rs2)));
+                riscv_write_d(vm, rds, fpu_add64(riscv_view_d(vm, rs1), riscv_view_d(vm, rs2)));
                 return;
             case RISCV_FPU_GEN_RM_CASES(0x08000000UL): // fsub.s
                 riscv_write_s(vm, rds, fpu_sub32(riscv_read_s(vm, rs1), riscv_read_s(vm, rs2)));
@@ -152,16 +152,16 @@ static slow_path void riscv_emulate_f_opc_op_impl(rvvm_hart_t* vm, const uint32_
                 riscv_write_d(vm, rds, fpu_sub64(riscv_view_d(vm, rs1), riscv_view_d(vm, rs2)));
                 return;
             case RISCV_FPU_GEN_RM_CASES(0x10000000UL): // fmul.s
-                riscv_emit_s(vm, rds, fpu_mul32(riscv_read_s(vm, rs1), riscv_read_s(vm, rs2)));
+                riscv_write_s(vm, rds, fpu_mul32(riscv_read_s(vm, rs1), riscv_read_s(vm, rs2)));
                 return;
             case RISCV_FPU_GEN_RM_CASES(0x12000000UL): // fmul.d
-                riscv_emit_d(vm, rds, fpu_mul64(riscv_view_d(vm, rs1), riscv_view_d(vm, rs2)));
+                riscv_write_d(vm, rds, fpu_mul64(riscv_view_d(vm, rs1), riscv_view_d(vm, rs2)));
                 return;
             case RISCV_FPU_GEN_RM_CASES(0x18000000UL): // fdiv.s
-                riscv_emit_s(vm, rds, fpu_div32(riscv_read_s(vm, rs1), riscv_read_s(vm, rs2)));
+                riscv_write_s(vm, rds, fpu_div32(riscv_read_s(vm, rs1), riscv_read_s(vm, rs2)));
                 return;
             case RISCV_FPU_GEN_RM_CASES(0x1A000000UL): // fdiv.d
-                riscv_emit_d(vm, rds, fpu_div64(riscv_view_d(vm, rs1), riscv_view_d(vm, rs2)));
+                riscv_write_d(vm, rds, fpu_div64(riscv_view_d(vm, rs1), riscv_view_d(vm, rs2)));
                 return;
             case RISCV_FPU_GEN_RM_CASES(0x58000000UL): // fsqrt.s
                 if (likely(!rs2)) {

--- a/src/cpu/riscv_fpu.h
+++ b/src/cpu/riscv_fpu.h
@@ -170,14 +170,14 @@ static forceinline void riscv_emulate_f_fmadd(rvvm_hart_t* vm, const uint32_t in
         const uint32_t prev_rm = riscv_fpu_static_rm_enter(rm);
         switch (bit_ext_u32(insn, 25, 2)) {
             case 0x0: // fmadd.s
-                riscv_emit_s(vm, rds,
+                riscv_write_s(vm, rds,
                              fpu_fma32(riscv_read_s(vm, rs1), //
                                        riscv_read_s(vm, rs2), //
                                        riscv_read_s(vm, rs3)));
                 riscv_fpu_static_rm_leave(prev_rm);
                 return;
             case 0x1: // fmadd.d
-                riscv_emit_d(vm, rds,
+                riscv_write_d(vm, rds,
                              fpu_fma64(riscv_view_d(vm, rs1), //
                                        riscv_view_d(vm, rs2), //
                                        riscv_view_d(vm, rs3)));
@@ -203,14 +203,14 @@ static forceinline void riscv_emulate_f_fmsub(rvvm_hart_t* vm, const uint32_t in
         const uint32_t prev_rm = riscv_fpu_static_rm_enter(rm);
         switch (bit_ext_u32(insn, 25, 2)) {
             case 0x0: // fmsub.s
-                riscv_emit_s(vm, rds,
+                riscv_write_s(vm, rds,
                              fpu_fma32(riscv_read_s(vm, rs1), //
                                        riscv_read_s(vm, rs2), //
                                        fpu_neg32(riscv_read_s(vm, rs3))));
                 riscv_fpu_static_rm_leave(prev_rm);
                 return;
             case 0x1: // fmsub.d
-                riscv_emit_d(vm, rds,
+                riscv_write_d(vm, rds,
                              fpu_fma64(riscv_view_d(vm, rs1), //
                                        riscv_view_d(vm, rs2), //
                                        fpu_neg64(riscv_view_d(vm, rs3))));
@@ -236,14 +236,14 @@ static forceinline void riscv_emulate_f_fnmsub(rvvm_hart_t* vm, const uint32_t i
         const uint32_t prev_rm = riscv_fpu_static_rm_enter(rm);
         switch (bit_ext_u32(insn, 25, 2)) {
             case 0x0: // fnmsub.s
-                riscv_emit_s(vm, rds,
+                riscv_write_s(vm, rds,
                              fpu_fma32(fpu_neg32(riscv_read_s(vm, rs1)), //
                                        riscv_read_s(vm, rs2),            //
                                        riscv_read_s(vm, rs3)));
                 riscv_fpu_static_rm_leave(prev_rm);
                 return;
             case 0x1: // fnmsub.d
-                riscv_emit_d(vm, rds,
+                riscv_write_d(vm, rds,
                              fpu_fma64(fpu_neg64(riscv_view_d(vm, rs1)), //
                                        riscv_view_d(vm, rs2),            //
                                        riscv_view_d(vm, rs3)));
@@ -270,14 +270,14 @@ static forceinline void riscv_emulate_f_fnmadd(rvvm_hart_t* vm, const uint32_t i
         switch (bit_ext_u32(insn, 25, 2)) {
             case 0x0: // fnmadd.s = -(rs1*rs2) - rs3; negate operands so the single
                        // rounding sees the correctly-signed result (directed modes)
-                riscv_emit_s(vm, rds,
+                riscv_write_s(vm, rds,
                              fpu_fma32(fpu_neg32(riscv_read_s(vm, rs1)), //
                                        riscv_read_s(vm, rs2),            //
                                        fpu_neg32(riscv_read_s(vm, rs3))));
                 riscv_fpu_static_rm_leave(prev_rm);
                 return;
             case 0x1: // fnmadd.d
-                riscv_emit_d(vm, rds,
+                riscv_write_d(vm, rds,
                              fpu_fma64(fpu_neg64(riscv_view_d(vm, rs1)), //
                                        riscv_view_d(vm, rs2),            //
                                        fpu_neg64(riscv_view_d(vm, rs3))));


### PR DESCRIPTION
# fpu: canonicalize NaN results of fadd/fmul/fdiv and fused ops

Fixes #254

## Description

The FP writeback for `fadd`, `fmul`, `fdiv` and the fused `fmadd/fmsub/fnmsub/fnmadd` family stores the raw host result, which keeps non-canonical NaN payloads. The `fsub`/`fmin`/`fmax` paths already canonicalize through the write helpers; the RISC-V specification requires the canonical NaN bit pattern for arithmetic results. Route the remaining arithmetic writebacks through the same canonicalizing writers.

Signaling-NaN `NV` flagging is unchanged.

## Validation

- qNaN-payload, `inf*0+1` and `0/0` probes match native RISC-V hardware and QEMU after the fix, with the JIT enabled and disabled.
- Every arithmetic result is the canonical NaN and `fflags` match the references.
