### PR TITLE
rvjit: clear the architectural low bit of JALR targets

### DIFF
--- a/src/rvjit/rvjit_emit.c
+++ b/src/rvjit/rvjit_emit.c
@@ -716,6 +716,7 @@ void rvjit32_jalr(rvjit_block_t* block, regid_t rds, regid_t rs, int32_t imm, ui
     regid_t hrs  = rvjit_map_reg(block, rs, REG_SRC);
     regid_t hjmp = rvjit_claim_hreg(block);
     rvjit32_native_addi(block, hjmp, hrs, imm);
+    rvjit32_native_andi(block, hjmp, hjmp, -2);
     if (rds != RVJIT_REGISTER_ZERO) {
         int32_t new_imm = block->pc_off + isize;
         regid_t hrds    = rvjit_map_reg(block, rds, REG_DST);
@@ -726,7 +727,7 @@ void rvjit32_jalr(rvjit_block_t* block, regid_t rds, regid_t rs, int32_t imm, ui
     }
 
     if (block->regs[rs].flags & REG_AUIPC) {
-        block->pc_off  = block->regs[rs].auipc_off + imm;
+        block->pc_off  = (block->regs[rs].auipc_off + imm) & ~1;
         block->linkage = LINKAGE_JMP;
     } else {
         block->pc_off  = 0;
@@ -770,6 +771,7 @@ void rvjit64_jalr(rvjit_block_t* block, regid_t rds, regid_t rs, int32_t imm, ui
     regid_t hrs  = rvjit_map_reg(block, rs, REG_SRC);
     regid_t hjmp = rvjit_claim_hreg(block);
     rvjit64_native_addi(block, hjmp, hrs, imm);
+    rvjit64_native_andi(block, hjmp, hjmp, -2);
     if (rds != RVJIT_REGISTER_ZERO) {
         int32_t new_imm = block->pc_off + isize;
         regid_t hrds    = rvjit_map_reg(block, rds, REG_DST);
@@ -780,7 +782,7 @@ void rvjit64_jalr(rvjit_block_t* block, regid_t rds, regid_t rs, int32_t imm, ui
     }
 
     if (block->regs[rs].flags & REG_AUIPC) {
-        block->pc_off  = block->regs[rs].auipc_off + imm;
+        block->pc_off  = (block->regs[rs].auipc_off + imm) & ~1;
         block->linkage = LINKAGE_JMP;
     } else {
         block->pc_off  = 0;


### PR DESCRIPTION
## Summary

The JIT emits an odd target for `JALR` when the calculated address has bit 0 set. RISC-V `JALR` clears that bit before the control transfer. Apply the mask in both the 32-bit and 64-bit JIT emission paths, including the AUIPC linkage shortcut.

## Validation

- Native RISC-V hardware and QEMU reach the aligned target.
- The interpreter is the independent same-tool control.
- The patch changes only the `JALR` target materialization in `src/rvjit/rvjit_emit.c`; the patched JIT reproduces the expected results with no exception log.

Fixes #257
