### PR TITLE
riscv: use the paired register in RV32 amocas.d

### DIFF
--- a/src/cpu/riscv_atomics.h
+++ b/src/cpu/riscv_atomics.h
@@ -423,7 +423,7 @@ static forceinline void riscv_emulate_atomic_dwcas(rvvm_hart_t* vm, const uint32
         write_uint64_le(&exp, riscv_read_reg(vm, rds) | (((uint64_t)riscv_read_reg(vm, rds + 1)) << 32));
     }
     if (rs2) {
-        write_uint64_le(&val, riscv_read_reg(vm, rs2) | (((uint64_t)riscv_read_reg(vm, rs2)) << 32));
+        write_uint64_le(&val, riscv_read_reg(vm, rs2) | (((uint64_t)riscv_read_reg(vm, rs2 + 1)) << 32));
     }
     atomic_cas_uint64_ex(ptr, &exp, val, false, ATOMIC_ACQ_REL, ATOMIC_ACQUIRE);
     if (rds) {


### PR DESCRIPTION
## Summary

The RV32 `amocas.d` emulation constructs the 64-bit exchange value from `rs2` twice. Read the high half from `rs2+1`, matching the paired-register encoding and the existing RV64 path.

## Validation

- Ten differential cases match the QEMU reference byte-for-byte with the patched build, with the JIT enabled and disabled.
- The patch is limited to the RV32 register-pair construction in `src/cpu/riscv_atomics.h`.

Fixes #258
