### PR TITLE
riscv: apply JALR bit-zero semantics to C.JR and C.JALR

### DIFF
--- a/src/cpu/riscv_compressed.h
+++ b/src/cpu/riscv_compressed.h
@@ -473,7 +473,8 @@ static forceinline void riscv_emulate_c_c2(rvvm_hart_t* vm, const uint32_t insn)
                 return;
             } else if (likely(rds)) { // c.jr
                 rvjit_trace_jalr(RISCV_REG_ZERO, rds, 0, 2);
-                riscv_write_reg(vm, RISCV_REG_PC, riscv_read_reg(vm, rds) - 2);
+                riscv_write_reg(vm, RISCV_REG_PC,
+                                (riscv_read_reg(vm, rds) & ~(xlen_t) 1) - 2);
                 riscv_voluntary_preempt(vm);
                 return;
             }
@@ -485,7 +486,8 @@ static forceinline void riscv_emulate_c_c2(rvvm_hart_t* vm, const uint32_t insn)
             } else if (likely(rds)) { // c.jalr
                 rvjit_trace_jalr(RISCV_REG_X1, rds, 0, 2);
                 riscv_write_reg(vm, RISCV_REG_X1, riscv_read_reg(vm, RISCV_REG_PC) + 2);
-                riscv_write_reg(vm, RISCV_REG_PC, riscv_read_reg(vm, rds) - 2);
+                riscv_write_reg(vm, RISCV_REG_PC,
+                                (riscv_read_reg(vm, rds) & ~(xlen_t) 1) - 2);
                 riscv_voluntary_preempt(vm);
             } else { // c.ebreak
                 riscv_breakpoint(vm);


### PR DESCRIPTION
# riscv: apply JALR bit-zero semantics to C.JR and C.JALR

Fixes #267

## Commit message

```text
riscv: apply JALR bit-zero semantics to C.JR and C.JALR

```

## Description

`C.JR` and `C.JALR` expand to `JALR`, but the compressed path writes the raw odd target to `PC`. Mask bit 0 before the transfer in both compressed paths; the link register behavior remains unchanged.
## Validation

- Native RV64 hardware and QEMU execute the odd-target controls at the aligned address.
- Interpreter and JIT paths are both validated against the references.
- The proposed change is limited to the compressed RISC-V decode path.
