### PR TITLE
riscv: enforce the fixed rs2 field for LR.W and LR.D

### DIFF
--- a/src/cpu/riscv_atomics.h
+++ b/src/cpu/riscv_atomics.h
@@ -186,6 +186,11 @@ static forceinline void riscv_emulate_atomic_w(rvvm_hart_t* vm, const uint32_t i
         riscv_illegal_insn(vm, insn);
         return;
     }
+    if (unlikely(op == RISCV_AMO_LR && rs2 != RISCV_REG_ZERO)) {
+        // LR.W encodes rs2 as a fixed zero field.
+        riscv_illegal_insn(vm, insn);
+        return;
+    }
     if (unlikely(vaddr & 3)) {
         // Misaligned atomic
         uint32_t cause = (op == RISCV_AMO_LR) ? RISCV_TRAP_LOAD_MISALIGN : RISCV_TRAP_STORE_MISALIGN;
@@ -283,6 +288,11 @@ static forceinline void riscv_emulate_atomic_d(rvvm_hart_t* vm, const uint32_t i
 
     if (unlikely(!((1U << op) & 0x1111113F))) {
         // Illegal instruction
+        riscv_illegal_insn(vm, insn);
+        return;
+    }
+    if (unlikely(op == RISCV_AMO_LR && rs2 != RISCV_REG_ZERO)) {
+        // LR.D encodes rs2 as a fixed zero field.
         riscv_illegal_insn(vm, insn);
         return;
     }


### PR DESCRIPTION
# riscv: enforce the fixed rs2 field for LR.W and LR.D

Fixes #266

## Commit message

```text
riscv: enforce the fixed rs2 field for LR.W and LR.D

```

## Description

The RISC-V `LR.W` and `LR.D` encodings require `rs2=x0`. RVVM currently dispatches non-zero `rs2` encodings as valid load-reserved operations. Reject those reserved encodings before the alignment and reservation path while preserving legal LR controls.
## Validation

- Invalid D/W encodings and legal controls were run on native RV64, QEMU, interpreter, JIT, fixed interpreter, and fixed JIT paths.
- The proposed change is limited to the two atomic LR helpers.
- The result matrix covers each execution lane and the fixed-field controls.
