### PR TITLE
rvjit: preserve immediate comparison semantics for x0 sources

### DIFF
--- a/src/rvjit/rvjit_emit.c
+++ b/src/rvjit/rvjit_emit.c
@@ -602,6 +602,26 @@ void rvjit_emit_end(rvjit_block_t* block, uint8_t linkage)
     RVJIT32_IMM(instr)                                                                                                 \
     RVJIT64_IMM(instr)
 
+#define RVJIT32_IMM_NO_ZERO_OPTIMIZE(instr)                                                                            \
+    void rvjit32_##instr(rvjit_block_t* block, regid_t rds, regid_t rs1, int32_t imm)                                  \
+    {                                                                                                                  \
+        RVJIT_2REG_IMM_OP(rvjit32_native_##instr, rds, rs1, imm);                                                      \
+    }
+
+#ifdef RVJIT_NATIVE_64BIT
+#define RVJIT64_IMM_NO_ZERO_OPTIMIZE(instr)                                                                            \
+    void rvjit64_##instr(rvjit_block_t* block, regid_t rds, regid_t rs1, int32_t imm)                                  \
+    {                                                                                                                  \
+        RVJIT_2REG_IMM_OP(rvjit64_native_##instr, rds, rs1, imm);                                                      \
+    }
+#else
+#define RVJIT64_IMM_NO_ZERO_OPTIMIZE(instr)
+#endif
+
+#define RVJIT_IMM_NO_ZERO_OPTIMIZE(instr)                                                                              \
+    RVJIT32_IMM_NO_ZERO_OPTIMIZE(instr)                                                                                \
+    RVJIT64_IMM_NO_ZERO_OPTIMIZE(instr)
+
 /*
  * Branch intrinsics
  */
@@ -661,8 +681,8 @@ RVJIT_IMM(andi)
 RVJIT_IMM(srai)
 RVJIT_IMM(srli)
 RVJIT_IMM(slli)
-RVJIT_IMM(slti)
-RVJIT_IMM(sltiu)
+RVJIT_IMM_NO_ZERO_OPTIMIZE(slti)
+RVJIT_IMM_NO_ZERO_OPTIMIZE(sltiu)
 
 RVJIT64_3REG(addw)
 RVJIT64_3REG(subw)


### PR DESCRIPTION
# rvjit: preserve immediate comparison semantics for x0 sources

Fixes #268

## Commit message

```text
rvjit: preserve immediate comparison semantics for x0 sources

```

## Description

The `RVJIT_IMM_ZERO_OPTIMIZE` peephole rewrites `SLTI` and `SLTIU` with `rs1=x0` as zero-producing operations. These are comparisons, so the result depends on the immediate (`slti rd,x0,1` is `1`). Use the non-zero-optimizing emission macros for both instructions.
## Validation

- Native RV64, QEMU, interpreter, and fixed-JIT controls were run; the witness outputs cover the aliasing and non-aliasing controls.
- The proposed change is limited to the two immediate-emitter registrations in `src/rvjit/rvjit_emit.c`.
- This root is separate from the division-overflow, `MULHSU` aliasing, `JALR` target-mask, compressed-jump, and `LR` fixed-field fixes.
