### PR TITLE
riscv: advance xperm8 output positions by one byte

### DIFF
--- a/src/cpu/riscv_base.h
+++ b/src/cpu/riscv_base.h
@@ -112,7 +112,7 @@ static inline func_clang_minsize uint64_t riscv_bit_xperm4(uint64_t val, uint64_
 static inline func_clang_minsize uint64_t riscv_bit_xperm8(uint64_t val, uint64_t lut)
 {
     uint64_t ret = 0;
-    for (size_t i = 0; i < 64; i += 4) {
+    for (size_t i = 0; i < 64; i += 8) {
         uint32_t idx = (lut >> i);
         if (!(idx & 0xF8)) {
             ret |= bit_ext_u64(val, (idx & 0x07) << 3, 8) << i;


### PR DESCRIPTION
# riscv: advance xperm8 output positions by one byte

Fixes #275

## Commit message

```text
riscv: advance xperm8 output positions by one byte

```

## Description

`riscv_bit_xperm8()` advances its output position by four bits although each `xperm8` element is one byte. The helper therefore writes overlapping byte results. Advance by eight bits so the identity-permutation and general byte controls have the architectural result.
## Validation

- The RV64 `Zbkx` witness, QEMU, and the recorded native/reference controls agree after the fix.
- The proposed change is one source-line change in `src/cpu/riscv_base.h`.
- The witness matrix covers indexed values and boundary controls.
