### PR TITLE
riscv: preserve fflags when rejecting a reserved frm value

### DIFF
--- a/src/cpu/riscv_csr.c
+++ b/src/cpu/riscv_csr.c
@@ -425,8 +425,8 @@ static void riscv_update_fcsr(rvvm_hart_t* vm, uint32_t old_fcsr, uint32_t new_f
         uint32_t new_fflags = bit_cut(new_fcsr, 0, 5);
         if (unlikely(new_frm != old_frm)) {
             if (new_frm > RM_RMM) {
-                // Invalid rounding mode written
-                return;
+                // Keep invalid frm, but still apply the other fcsr fields
+                new_frm = old_frm;
             } else {
                 // Set host rounding mode
                 fpu_set_rounding_mode(new_frm);
@@ -438,7 +438,7 @@ static void riscv_update_fcsr(rvvm_hart_t* vm, uint32_t old_fcsr, uint32_t new_f
                 fpu_set_exceptions(0);
             }
         }
-        vm->csr.fcsr = new_fcsr;
+        vm->csr.fcsr = new_fflags | (new_frm << 5);
     }
 }
 


### PR DESCRIPTION
# riscv: preserve fflags when rejecting a reserved frm value

Fixes #274

## Commit message

```text
riscv: preserve fflags when rejecting a reserved frm value

```

## Description

`riscv_update_fcsr()` currently returns before committing the writable `fflags` field when the incoming `frm` value is reserved. Keep the old/WARL `frm` value, apply the independent `fflags` bits, and reconstruct the final CSR from the validated fields. The change is limited to `src/cpu/riscv_csr.c` and applies independently to `staging`; validation artifacts stay out of the source diff.
## Validation

- The witness runs on native RISC-V hardware and QEMU and on the affected RVVM build; the isolated patched build matches both references.
- Both the interpreter and JIT lanes were exercised, and the patched build is limited to this root.
