### PR TITLE
riscv: sign-extend operands in signed byte atomics

### DIFF
--- a/src/cpu/riscv_atomics.h
+++ b/src/cpu/riscv_atomics.h
@@ -42,7 +42,7 @@ static forceinline void riscv_emulate_atomic_b(rvvm_hart_t* vm, const uint32_t i
     const size_t   rs1   = bit_ext_u32(insn, 15, 5);
     const size_t   rs2   = bit_ext_u32(insn, 20, 5);
     const xaddr_t  vaddr = riscv_read_reg(vm, rs1);
-    const uint8_t  val   = riscv_read_reg(vm, rs2);
+    const int16_t  val   = (int16_t)(int8_t)riscv_read_reg(vm, rs2);
     uint8_t        buf   = 0;
     void*          ptr   = NULL;
 

--- a/src/util/atomics.h
+++ b/src/util/atomics.h
@@ -1967,7 +1967,7 @@ static inline int16_t atomic_max_int8(void* addr, int16_t val)
 {
     int16_t tmp;
     do {
-        tmp = atomic_load_uint8(addr);
+        tmp = (int16_t)(int8_t)atomic_load_uint8(addr);
     } while (!atomic_cas_uint8(addr, tmp, tmp > val ? tmp : val));
     return tmp;
 }
@@ -1976,7 +1976,7 @@ static inline int16_t atomic_min_int8(void* addr, int16_t val)
 {
     int16_t tmp;
     do {
-        tmp = atomic_load_uint8(addr);
+        tmp = (int16_t)(int8_t)atomic_load_uint8(addr);
     } while (!atomic_cas_uint8(addr, tmp, tmp < val ? tmp : val));
     return tmp;
 }


### PR DESCRIPTION
# riscv: sign-extend operands in signed byte atomics

Fixes #276

## Commit message

```text
riscv: sign-extend operands in signed byte atomics

```

## Description

The signed `amomin.b`/`amomax.b` emulation compares zero-extended bytes. Sign-extend both the memory byte and the low byte of `rs2` before entering the signed comparison helper. The change is limited to `src/util/atomics.h` and `src/cpu/riscv_atomics.h`; validation artifacts stay out of the source diff.
## Validation

- The witness runs on native RISC-V hardware and QEMU and on the affected RVVM build; the isolated patched build matches both references.
- Both the interpreter and JIT lanes were exercised, and the patched build is limited to this root.
