### PR TITLE
riscv: trap reserved C.LUI/C.ADDI16SP encodings instead of mis-decoding them

### DIFF
--- a/src/cpu/riscv_compressed.h
+++ b/src/cpu/riscv_compressed.h
@@ -252,7 +252,10 @@ static forceinline void riscv_emulate_c_c1(rvvm_hart_t* vm, const uint32_t insn)
                 riscv_write_reg(vm, rds, (int32_t)(riscv_read_reg(vm, rds) + imm));
                 return;
             }
-            break;
+            // c.addiw with rd == x0 is a reserved encoding (spec: valid only
+            // when rd != x0); trap instead of falling through or executing
+            riscv_illegal_insn(vm, insn);
+            return;
 #else
             const xlen_t  pc  = riscv_read_reg(vm, RISCV_REG_PC);
             const int32_t off = decode_c_jal_imm(insn);
@@ -286,7 +289,9 @@ static forceinline void riscv_emulate_c_c1(rvvm_hart_t* vm, const uint32_t insn)
             } else if ((rds & 0x01) && !(rds & 0x10)) { // c.mop.{1,15}
                 return;
             }
-            break;
+            // Reserved: c.lui/c.addi16sp with nzimm == 0 (and not a valid c.mop)
+            riscv_illegal_insn(vm, insn);
+            return;
         }
         case 0x05: { // c.j
             const int32_t off = decode_c_jal_imm(insn);


### PR DESCRIPTION
# Fix: trap reserved C.LUI/C.ADDI16SP and C.ADDIW rd=x0 encodings

## Problem

`riscv_emulate_c_c1()` in `src/cpu/riscv_compressed.h` falls through from the
reserved `c.lui`/`c.addi16sp`/`c.mop` code points into the `c.misc-alu`
decoder, executing reserved encodings as `c.srli`/`c.srai`/`c.andi`/`c.sub`-
family instructions. The RV64 `c.addiw` `rd == x0` code points are also
reserved per the spec ("valid only when rd != x0") and fell through the same
way.

## Change

Both affected paths now return explicitly instead of falling through:

- `case 0x01` (RV64): `c.addiw` with `rd == x0` (reserved) -> `riscv_illegal_insn()`
- `case 0x03`: `c.lui`/`c.addi16sp` with `nzimm == 0` that is not a valid `c.mop.N`
  -> `riscv_illegal_insn()`

## Verification

- 24 reserved `c.lui`-slot encodings: trap on native RISC-V hardware (SIGILL), QEMU
  (SIGILL), and now RVVM (both JIT and interpreter).
- RV64 `c.addiw x0, imm` reserved encodings: now raise an illegal-instruction
  trap, matching the spec and QEMU (`c64_illegal`).
- Regression: `c.lui x0, 1` hint, `c.mop.N` (Zcmop), `c.addiw` with `rd != 0`,
  and all other C1 encodings still execute correctly.

Fixes #284.
