### PR TITLE
riscv: reject reserved shamt[5] bit of C.SLLI/C.SRLI/C.SRAI on RV32

### DIFF
--- a/src/cpu/riscv_compressed.h
+++ b/src/cpu/riscv_compressed.h
@@ -326,12 +326,24 @@ static forceinline void riscv_emulate_c_c1(rvvm_hart_t* vm, const uint32_t insn)
 
     switch (bit_ext_u32(insn, 10, 2)) {
         case 0x00: { // c.srli
+#if !defined(RISCV64)
+            if (unlikely(insn & 0x1000)) { // shamt[5] is reserved in RV32
+                riscv_illegal_insn(vm, insn);
+                return;
+            }
+#endif
             const bitcnt_t shamt = decode_c_shamt(insn);
             rvjit_trace_srli(rds, rds, shamt, 2);
             riscv_write_reg(vm, rds, reg1 >> shamt);
             return;
         }
         case 0x01: { // c.srai
+#if !defined(RISCV64)
+            if (unlikely(insn & 0x1000)) { // shamt[5] is reserved in RV32
+                riscv_illegal_insn(vm, insn);
+                return;
+            }
+#endif
             const bitcnt_t shamt = decode_c_shamt(insn);
             rvjit_trace_srai(rds, rds, shamt, 2);
             riscv_write_reg(vm, rds, ((sxlen_t)reg1) >> shamt);
@@ -421,6 +433,12 @@ static forceinline void riscv_emulate_c_c2(rvvm_hart_t* vm, const uint32_t insn)
     switch (bit_ext_u32(insn, 12, 4)) {
         case 0x00:
         case 0x01: { // c.slli
+#if !defined(RISCV64)
+            if (unlikely(insn & 0x1000)) { // shamt[5] is reserved in RV32
+                riscv_illegal_insn(vm, insn);
+                return;
+            }
+#endif
             const uint32_t shamt = decode_c_shamt(insn);
             rvjit_trace_slli(rds, rds, shamt, 2);
             riscv_write_reg(vm, rds, riscv_read_reg(vm, rds) << shamt);


### PR DESCRIPTION
# Fix: reject reserved shamt[5] bit of C.SLLI/C.SRLI/C.SRAI on RV32

## Problem

`decode_c_shamt()` ignores bit 12 for RV32, and the three compressed-shift
decoders (`c.slli`, `c.srli`, `c.srai`) never check it, so 1536 reserved RV32
encodings (bit 12 == 1, i.e. `shamt[5]`) are executed as valid shifts instead
of raising an illegal-instruction exception.

## Change

Add an RV32-only check at the top of each shift decoder that raises an
illegal-instruction trap when bit 12 is set:

```c
#if !defined(RISCV64)
            if (unlikely(insn & 0x1000)) { // shamt[5] is reserved in RV32
                riscv_illegal_insn(vm, insn);
                return;
            }
#endif
```

RV64 behavior is unchanged (bit 12 is the valid `shamt[5]`).

## Verification

- 8 sampled reserved encodings (0x1002/0x1082/0x1086, 0x9001/0x9005/0x9009,
  0x9101/0x9105) now trap on both the JIT and interpreter paths, matching QEMU.
- Regression: legal `c.slli`/`c.srli`/`c.srai` (including the `rd == x0` hints)
  and `c.andi` still execute correctly.

Fixes #285.
