### PR TITLE
riscv: gate fmvh.x.d on RV32

### DIFF
--- a/src/cpu/riscv_fpu.c
+++ b/src/cpu/riscv_fpu.c
@@ -390,7 +390,7 @@ static slow_path void riscv_emulate_f_opc_op_impl(rvvm_hart_t* vm, const uint32_
                 if (likely(vm->rv64 && !rs2)) { // fmv.x.d (RV64)
                     riscv_write_reg(vm, rds, (int64_t)fpu_bit_f64_to_u64(riscv_view_d(vm, rs1)));
                     return;
-                } else if (rs2 == 1) { // fmvh.x.d (Zfa, RV32)
+                } else if (!vm->rv64 && rs2 == 1) { // fmvh.x.d (Zfa, RV32)
                     riscv_write_reg(vm, rds, (int32_t)(fpu_bit_f64_to_u64(riscv_view_d(vm, rs1)) >> 32));
                     return;
                 }


### PR DESCRIPTION
# riscv: gate fmvh.x.d on RV32

Fixes #291

## Commit message
```text
riscv: gate fmvh.x.d on RV32
```
## Description
`fmvh.x.d` is a Zfa RV32 instruction. The RVVM decode branch currently checks `rs2 == 1` without checking the configured XLEN, so the same code point is accepted on RV64. Add the missing `!vm->rv64` condition; no other floating-point operation is changed.
## Validation
- Native RISC-V hardware and QEMU both trap `0xe2150553` (`fmvh.x.d a0, fa0`) on RV64; the patched build matches and retires only the RV32 form.
