### PR TITLE
fpu: canonicalize sqrt NaN results

### DIFF
--- a/src/util/fpu_lib.h
+++ b/src/util/fpu_lib.h
@@ -1160,6 +1160,12 @@ static forceinline fpu_f64_t fpu_fma64(fpu_f64_t a, fpu_f64_t b, fpu_f64_t c)
 
 static forceinline fpu_f32_t fpu_sqrt32(fpu_f32_t f)
 {
+    if (unlikely(fpu_is_nan32_soft(f))) {
+        if (fpu_is_snan32_soft(f)) {
+            fpu_raise_invalid();
+        }
+        return fpu_bit_u32_to_f32(FPU_LIB_FP32_CANONICAL_NAN);
+    }
     if (likely(fpu_is_positive32(f))) {
 #if defined(USE_SOFT_FPU_SQRT)
         fpu_f32_t ret = fpu_sqrt32_soft_internal(f);
@@ -1182,6 +1188,12 @@ static forceinline fpu_f32_t fpu_sqrt32(fpu_f32_t f)
 
 static forceinline fpu_f64_t fpu_sqrt64(fpu_f64_t d)
 {
+    if (unlikely(fpu_is_nan64_soft(d))) {
+        if (fpu_is_snan64_soft(d)) {
+            fpu_raise_invalid();
+        }
+        return fpu_bit_u64_to_f64(FPU_LIB_FP64_CANONICAL_NAN);
+    }
     if (likely(fpu_is_positive64(d))) {
 #if defined(USE_SOFT_FPU_SQRT)
         fpu_f64_t ret = fpu_sqrt64_soft_internal(d);


### PR DESCRIPTION
# fpu: canonicalize sqrt NaN results

Fixes #292

## Commit message
```text
fpu: canonicalize sqrt NaN results
```
## Description
The `fsqrt.s` and `fsqrt.d` wrappers test the sign before classifying NaNs. Positive qNaNs therefore return their payload unchanged, and signaling NaNs do not consistently raise `NV`. Handle NaNs first, canonicalize both precisions, and raise invalid only when the input is signaling. The existing negative finite-input and signed-zero behavior remains unchanged.
## Validation
- Native RISC-V hardware and QEMU return the canonical qNaN for qNaN inputs and set `NV` for signaling NaNs; the patched build matches on the single- and double-precision witness matrix.
