### PR TITLE
riscv: return after valid fcvtmod.w.d

### DIFF
--- a/src/cpu/riscv_fpu.c
+++ b/src/cpu/riscv_fpu.c
@@ -245,6 +245,7 @@ static slow_path void riscv_emulate_f_opc_op_impl(rvvm_hart_t* vm, const uint32_
                     case 0x08: // fcvtmod.w.d (Zfa)
                         if (likely(rm == 0x01)) {
                             riscv_write_reg(vm, rds, (int32_t)fpu_fcvt_f64_to_i32(riscv_view_d(vm, rs1)));
+                            return;
                         }
                         break;
                 }


### PR DESCRIPTION
# riscv: return after valid fcvtmod.w.d

Fixes #294

## Commit message
```text
riscv: return after valid fcvtmod.w.d
```
## Description
The valid `fcvtmod.w.d` path writes the integer result and then falls through to the illegal-instruction path because it lacks a return. Add the missing return immediately after the architectural writeback. Reserved rounding-mode encodings continue to use the existing illegal path. The change is limited to `src/cpu/riscv_fpu.c`.

This PR is independently applicable to `staging`. PR #304 addresses the
separate modulo-conversion semantics in the same instruction, and no longer
contains this control-flow hunk; the two fixes can be reviewed and merged
independently.

## Validation
- QEMU with Zfa executes `0xc2801553` and retires the legal `rtz` form; the patched RVVM also retires it with `rd = 3` and no internal illegal-instruction exception. A native RV64 reference without Zfa is recorded only as a capability boundary, not as the expected behaviour of RVVM's Zfa-enabled guest.
