### PR TITLE
riscv: write zero for default Zimop MOPs

### DIFF
--- a/src/cpu/riscv_priv.c
+++ b/src/cpu/riscv_priv.c
@@ -169,6 +169,7 @@ slow_path void riscv_emulate_opc_system(rvvm_hart_t* vm, const uint32_t insn)
         }
         case 0x04:
             if ((insn & 0xB0000000UL) == 0x80000000UL) { // mop.r.{0,31}, mop.rr.{0,7} (Zimop)
+                vm->registers[rds] = 0;
                 return;
             }
             break;


### PR DESCRIPTION
# riscv: write zero for default Zimop MOPs

Fixes #305

## Commit message
```text
riscv: write zero for default Zimop MOPs
```
## Description
The accepted `mop.r`/`mop.rr` decode path returns without performing the architectural default writeback. The Zimop default operation writes zero to `x[rd]`; add that writeback while leaving extension-admission policy unchanged. The change is limited to `src/cpu/riscv_priv.c` and applies independently to the `staging` branch.
## Validation
- Native RISC-V hardware and QEMU are the references; disabled-extension code points trap, while the default `Zimop` operation writes `rd = 0` on the `mop.r.0`, `mop.r.31`, `mop.rr.0` and `mop.rr.7` witnesses.
