### PR TITLE
riscv: avoid FMA error recovery for directed fmadd.s

### DIFF
--- a/src/util/fpu_lib.h
+++ b/src/util/fpu_lib.h
@@ -1070,9 +1070,26 @@ static forceinline func_opt_size fpu_f32_t fpu_fma32(fpu_f32_t a, fpu_f32_t b, f
     fpu_f64_t mul = fpu_mul64(fpu_fcvt_f32_to_f64(a), fpu_fcvt_f32_to_f64(b));
     fpu_f64_t add = fpu_fcvt_f32_to_f64(c);
     fpu_f64_t sum = fpu_add64(mul, add);
+    uint32_t sum_exceptions = fpu_get_exceptions();
     fpu_f64_t err = fpu_add_error64(sum, mul, add);
-    fpu_f64_t res = fpu_odd_round64(sum, err);
-    fpu_f32_t ret = fpu_fcvt_f64_to_f32(res);
+    const uint32_t mode = fpu_get_rounding_mode();
+    fpu_f32_t ret;
+    if (mode == FPU_LIB_ROUND_TZ || mode == FPU_LIB_ROUND_DN || mode == FPU_LIB_ROUND_UP) {
+        ret = fpu_fcvt_f64_to_f32(sum);
+        const bool inexact = (sum_exceptions & ~old_exceptions & FPU_LIB_FLAG_NX) != 0;
+        uint32_t exceptions = fpu_get_exceptions();
+        exceptions = (exceptions & ~(FPU_LIB_FLAG_NX | FPU_LIB_FLAG_UF)) |
+                     (old_exceptions & (FPU_LIB_FLAG_NX | FPU_LIB_FLAG_UF));
+        if (inexact) {
+            exceptions |= FPU_LIB_FLAG_NX;
+            if ((fpu_bit_f32_to_u32(ret) & FPU_LIB_FP32_NOSIGNED_MASK) < FPU_LIB_FP32_MINIMUM_NORM) {
+                exceptions |= FPU_LIB_FLAG_UF;
+            }
+        }
+        fpu_set_exceptions(exceptions);
+    } else {
+        ret = fpu_fcvt_f64_to_f32(fpu_odd_round64(sum, err));
+    }
 #if defined(USE_SOFT_FPU_FENV)
     fpu_soft_fenv_check_add64(fpu_fcvt_f32_to_f64(ret), sum, err);
 #endif


### PR DESCRIPTION
# riscv: avoid FMA error recovery for directed fmadd.s

Fixes #309

## Commit message

```text
riscv: avoid FMA error recovery for directed fmadd.s

```

## Description

The `fpu_fma32` error-recovery calculation is exact only for RNE. For directed modes it can cross an f32 grid point and under-report `UF`. Apply the f32-specific single-rounding path, preserve the NX raised by the preceding f64 sum, and discard only the later TwoSum flags that are not guest-visible. The change is limited to `src/util/fpu_lib.h`; validation artifacts stay out of the source diff.
## Validation

- The witness runs on native RISC-V hardware, QEMU, and the affected RVVM build; the patched build matches both references.
- Both the interpreter and JIT lanes were exercised, and the patched build is limited to this root.

The patch is independently applicable to the `staging` branch. Its scope is
finite `fmadd.s` directed rounding under RTZ/RDN/RUP; other FMA root causes
remain outside this patch.
