### PR TITLE
riscv: don't leak spurious NX from the FMA error-recovery path

### DIFF
--- a/src/util/fpu_lib.h
+++ b/src/util/fpu_lib.h
@@ -688,7 +688,7 @@ static inline fpu_f32_t fpu_odd_round32(fpu_f32_t val, fpu_f32_t err)
 {
     uint32_t uv = fpu_bit_f32_to_u32(val);
     uint32_t ue = fpu_bit_f32_to_u32(err);
-    if (ue && !(uv & 1)) {
+    if ((ue & 0x7FFFFFFFU) && !(uv & 1)) {
         if (ue >> 31) {
             return fpu_bit_u32_to_f32(uv - 1);
         } else {
@@ -702,7 +702,7 @@ static inline fpu_f64_t fpu_odd_round64(fpu_f64_t val, fpu_f64_t err)
 {
     uint64_t uv = fpu_bit_f64_to_u64(val);
     uint64_t ue = fpu_bit_f64_to_u64(err);
-    if (ue && !(uv & 1)) {
+    if ((ue & 0x7FFFFFFFFFFFFFFFULL) && !(uv & 1)) {
         if (ue >> 63) {
             return fpu_bit_u64_to_f64(uv - 1);
         } else {
@@ -1070,7 +1070,15 @@ static forceinline func_opt_size fpu_f32_t fpu_fma32(fpu_f32_t a, fpu_f32_t b, f
     fpu_f64_t mul = fpu_mul64(fpu_fcvt_f32_to_f64(a), fpu_fcvt_f32_to_f64(b));
     fpu_f64_t add = fpu_fcvt_f32_to_f64(c);
     fpu_f64_t sum = fpu_add64(mul, add);
+#if defined(FENV_SSE2_IMPL)
+    uint32_t sum_exceptions = fpu_get_exceptions();
+#endif
     fpu_f64_t err = fpu_add_error64(sum, mul, add);
+#if defined(FENV_SSE2_IMPL)
+    uint32_t cleared_exceptions = fpu_get_exceptions();
+    cleared_exceptions = (cleared_exceptions & ~FPU_LIB_FLAG_NX) | (sum_exceptions & FPU_LIB_FLAG_NX);
+    fpu_set_exceptions(cleared_exceptions);
+#endif
     fpu_f64_t res = fpu_odd_round64(sum, err);
     fpu_f32_t ret = fpu_fcvt_f64_to_f32(res);
 #if defined(USE_SOFT_FPU_FENV)
@@ -1098,13 +1106,26 @@ static forceinline fpu_f64_t fpu_fma64_raw(fpu_f64_t a, fpu_f64_t b, fpu_f64_t c
 #if defined(FPU_LIB_OPTIMAL_BUILTIN_FMA)
     return fpu_wrap_f64(__builtin_fma(fpu_raw_f64(a), fpu_raw_f64(b), fpu_raw_f64(c)));
 #else
+#if defined(FENV_SSE2_IMPL)
+    const uint32_t old_exceptions = fpu_get_exceptions();
+#endif
     fpu_f64_t mul = fpu_mul64(a, b);
     fpu_f64_t e_m = fpu_mul_error64(mul, a, b);
     fpu_f64_t sum = fpu_add64(mul, c);
     fpu_f64_t e_s = fpu_add_error64(sum, mul, c);
     fpu_f64_t e_f = fpu_add64(e_m, e_s);
     fpu_f64_t err = fpu_odd_round64(e_f, fpu_add_error64(e_f, e_s, e_m));
+#if defined(FENV_SSE2_IMPL)
+    fpu_f64_t ret = fpu_add64(sum, err);
+    fpu_f64_t final_error = fpu_add_error64(ret, sum, err);
+    uint32_t exceptions = fpu_get_exceptions();
+    exceptions = (exceptions & ~FPU_LIB_FLAG_NX) | (old_exceptions & FPU_LIB_FLAG_NX);
+    if (!fpu_is_zero64_soft(final_error)) exceptions |= FPU_LIB_FLAG_NX;
+    fpu_set_exceptions(exceptions);
+    return ret;
+#else
     return fpu_add64(sum, err);
+#endif
 #endif
 }
 


### PR DESCRIPTION
# riscv: don't leak spurious NX from the FMA error-recovery path

Fixes #310

## Commit message

```text
riscv: fix spurious NX on exact fused multiply-add results

The software FMA fallback (fpu_lib.h, used on hosts without the
builtin fused op) runs the TwoSum error-recovery intermediates on the
host f64 unit.  For exactly representable results those intermediates
can set the host inexact flag, which is then reported to the guest as
fflags.NX even though no rounding occurred.  Additionally the odd-round
helpers treat a -0.0 error term as a nonzero negative error and nudge
the value by one ulp, making an exact f32 grid-point result inexact in
the subsequent conversion.

Fix both: mask the sign bit in the odd-round nonzero test, and clear only
newly raised host NX immediately before the single final rounding of the
software fallback (the f64->f32 conversion for fmadd.s and the final
sum+err add for fmadd.d), preserving any NX already sticky before the
instruction.
```

## Description

`fpu_fma32`/`fpu_fma64_raw` in `src/util/fpu_lib.h` compute the fused value with host f64 arithmetic plus a TwoSum error-recovery pass. When the exact result is representable in the destination format, the recovery intermediates can still raise the host inexact flag, and `fpu_odd_round32`/`fpu_odd_round64` also treat a `-0.0` error term (returned for an exact sum) as a nonzero negative error, nudging the value off the exact grid point. Both effects produce a spurious guest `fflags.NX` on exact results.

The change masks the sign bit in the odd-round nonzero test and clears only newly raised NX around the single final rounding step of each software fallback. In `fpu_fma32` it preserves NX raised by the first f64 sum; in `fpu_fma64_raw` the final add establishes the instruction's NX, with a residual check covering hosts whose excess precision does not set the host flag. Both paths preserve NX that was already set before the instruction. The host-flag reconciliation is gated to the SSE2 fallback used by the affected x86-64 configuration; the legacy x87 path keeps its existing platform-specific exception handling. Result bits are unchanged in all cases (verified by differential testing).
## Validation

- Witnesses `fmadd.s rdn` (exact `-2^-46`) and `fmadd.d`/`fnmadd.d` (exact `+/-2^-104`): unmodified RVVM reports `fflags=1`; the patched build reports `fflags=0` with identical result bits, matching native RISC-V hardware and QEMU.
- Both interpreter and x86 JIT lanes exercised.
- 152-case fixed-input differential: only the three witness cases change (all become correct); zero new differences.
- 200000-case random differential of `fpu_fma64` with finite normal-range operands: zero result-bit and zero NX-flag differences.

The patch is independently applicable to the `staging` branch and does not
depend on an unmerged FMA change.
